### PR TITLE
Fix input of specific humidity but no pressure

### DIFF
--- a/src/initialize_atmos.c
+++ b/src/initialize_atmos.c
@@ -1205,7 +1205,7 @@ void initialize_atmos(atmos_data_struct        *atmos,
 
   } // end if VP not supplied
 
-  if if ((!param_set.TYPE[VP].SUPPLIED || param_set.FORCE_DT[param_set.TYPE[VP].SUPPLIED-1] == 24) && param_set.TYPE[PRESSURE].SUPPLIED ) {
+  if if ((!param_set.TYPE[VP].SUPPLIED || param_set.FORCE_DT[param_set.TYPE[VP].SUPPLIED-1] == 24) &&  !(!param_set.TYPE[PRESSURE].SUPPLIED && param_set.TYPE[QAIR].SUPPLIED)) {
 
     /**************************************************
       Either no observations of VP, QAIR, or REL_HUMID were supplied,


### PR DESCRIPTION
This part of the code is tricky because the # of combination of inputs is varied and affects the paths that the code follows through a series of 'if's. In my case, I input specific humidity (QAIR) at the daily time scale. Before the fix, the code was overwriting the QAIR of the input file by MTCLIM-calculated QAIR. 

The issue is that if you provide QAIR AND atmospheric pressure (Patm) at the daily time scale, then the model estimates vapor pressure (VP) at the daily time scale and feeds it to MTCLIM. Later on this VP, is interpolated to the subdaily time scale. However if you only provide QAIR then VP is estimated after Patm is calculated. This happens after MTCLIM is run and temperatures at the subdaily time scale are available (based on MTCLIM-derived hourly short wave rad). The VP calculated from QAIR then is subdaily too, being a function of subdaily temperature. Since this VP is subdaily, there's no need for interpolation to the subdaily time scale. This VP is written on the array that carries VP to the rest of VIC

This is what this fix does, it makes the code skip the subdaily interpolation of VP. Even if QAIR is provided at the daily time scale, if Patm is not provided, the algorithm doesn't need do the subdaily interpolation, and thus does not overwrites the VP calculated with the input QAIR, that would if it went into the interpolation. In the interpolation daily VP obtained by MTCLIM or other methods is written at the subdaily time scale into the array that carries VP to the rest of VIC.

A caveat here is that daily shortwave radiation, if not provided by the user, is estimated with the VP calculated within MTCLIM, and not by the VP calculated with the supplied QAIR. If we wanted to calculate VP with QAIR before MTCLIM though, to avoid this caveat, we would need to make assumptions about the air temperature to estimate Patm... In addition, doing so would require re-structuring this file quite a bit. This is not the case in most simulations where if QAIR daily is specified, most likely SHORTWAVE is also specified.

Homero
