### PR TITLE
Fixed the use of uninitialized soil moisture array on first time step.

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -33,6 +33,23 @@ Usage:
 Bug Fixes:
 ----------
 
+Fixed use of uninitialized soil moisture values on first time step.
+
+	Files Affected:
+
+	initialize_model_state.c
+
+	Description:
+
+	The tmp_moist array, used in initialize_model_state() as an input to
+	compute_runoff_and_asat(), was initialized within an if statement that
+	caused it to be sent to compute_runoff_and_asat() without initialization
+	in some cases.  This has been fixed by moving the initialization of
+	tmp_moist outside the if statement.
+
+
+
+
 Fixed errors in forcing disaggregation under certain input cases.
 
 	Files Affected:

--- a/src/initialize_model_state.c
+++ b/src/initialize_model_state.c
@@ -115,6 +115,9 @@ int initialize_model_state(dist_prcp_struct    *prcp,
   2012-Jan-16 Removed LINK_DEBUG code					BN
   2012-Jan-28 Added stability check for case of (FROZEN_SOIL=TRUE &&
 	      IMPLICIT=FALSE).						TJB
+  2013-Jul-30 Moved computation of tmp_moist argument of
+	      compute_runoff_and_asat() so that it would always be
+	      initialized.						TJB
 **********************************************************************/
 {
   extern option_struct options;
@@ -377,7 +380,6 @@ int initialize_model_state(dist_prcp_struct    *prcp,
               cell[dist][veg][band].layer[lidx].ice *= soil_con->max_moist[lidx]/cell[dist][veg][band].layer[lidx].moist;
 #endif
               cell[dist][veg][band].layer[lidx].moist = soil_con->max_moist[lidx];
-              tmp_moist[lidx] = cell[dist][veg][band].layer[lidx].moist;
 	    }
 
 #if SPATIAL_FROST
@@ -389,6 +391,7 @@ int initialize_model_state(dist_prcp_struct    *prcp,
             if (cell[dist][veg][band].layer[lidx].ice > cell[dist][veg][band].layer[lidx].moist)
               cell[dist][veg][band].layer[lidx].ice = cell[dist][veg][band].layer[lidx].moist;
 #endif
+            tmp_moist[lidx] = cell[dist][veg][band].layer[lidx].moist;
 
 	  }
           compute_runoff_and_asat(soil_con, tmp_moist, 0, &(cell[dist][veg][band].asat), &tmp_runoff);


### PR DESCRIPTION
Please (if possible) add this fix to hotfix/VIC_4.1.2.h and (definitely) merge it into the master branch.
