### PR TITLE
fix to longwave radiation in mtclim when dailyshortwave is an input

### DIFF
--- a/src/mtclim_constants_vic.h
+++ b/src/mtclim_constants_vic.h
@@ -104,7 +104,6 @@ typedef struct
   /* start vic_change */
   double *s_tskc;	 /* array of cloudiness values */
   double *s_ppratio; /* array of pet/prcp ratio values */
-  double *s_potrad; /* array of potential rad values */
   double *s_ttmax; /* array of clear sky transmittance values */
   double *s_tfmax; /* array of cloud transmittance factor values */
   /* end vic_change */

--- a/src/mtclim_vic.c
+++ b/src/mtclim_vic.c
@@ -386,10 +386,6 @@ int data_alloc(const control_struct *ctrl, data_struct *data)
     printf("Error allocating for site pet/prcp ratio array\n");
     ok=0;
   }
-  if (ok && !(data->s_potrad = (double*) malloc(ndays * sizeof(double)))) {
-    printf("Error allocating for site pet/prcp ratio array\n");
-    ok=0;
-  }
   if (ok && !(data->s_ttmax = (double*) malloc(ndays * sizeof(double)))) {
     printf("Error allocating for site pet/prcp ratio array\n");
     ok=0;
@@ -1104,6 +1100,7 @@ void compute_srad_humidity_onetime(int ndays, const control_struct *ctrl, data_s
   double srad1;
   double srad2;
   double sc;
+  double potrad;
   double tmink;
   double ratio;
   double ratio2;
@@ -1167,9 +1164,9 @@ void compute_srad_humidity_onetime(int ndays, const control_struct *ctrl, data_s
     /* save daily radiation */
     /* save cloud transmittance when rad is an input */
     if (ctrl->insw) {
-      data->s_potrad[i] = (srad1+srad2+sc)*daylength[yday]/t_final/86400;
-      if (data->s_potrad[i]>0 && data->s_srad[i]>0 && daylength[yday]>0) {
-	data->s_tfmax[i] = (data->s_srad[i])/(data->s_potrad[i]*t_tmax);//both of these are 24hr mean rad. here
+      potrad = (srad1+srad2+sc)*daylength[yday]/t_final/86400;
+      if (potrad>0 && data->s_srad[i]>0 && daylength[yday]>0) {
+	data->s_tfmax[i] = (data->s_srad[i])/(potrad*t_tmax);//both of these are 24hr mean rad. here
 	if (data->s_tfmax[i] > 1.0) data->s_tfmax[i] = 1.0;
       }
       else {
@@ -1237,7 +1234,6 @@ int data_free(const control_struct *ctrl, data_struct *data)
   free(data->s_swe);
   /* start vic_change */
   free(data->s_tskc);
-  free(data->s_potrad);
   free(data->s_ppratio);
   free(data->s_tfmax);
   free(data->s_ttmax);


### PR DESCRIPTION
This is the fix to the longwave radiation problem. It was an issue of units. We were correcting for mean-radiation-over-daylight to mean-radiation-over-24-hours twice.
