### PR TITLE
Fixed uninitialized dummy* variables.

### DIFF
--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -33,6 +33,22 @@ Usage:
 Bug Fixes:
 ----------
 
+Uninitialized variables in write_forcing_file().
+
+	Files Affected:
+
+	write_forcing_file.c
+
+	Description:
+
+	Placeholder variables (dummy_*) in write_forcing_file() were not
+	initialized, resulting in warnings during compilation.  These are now
+	initialized.  This should not affect any model results, since these
+	variables were never used.
+
+
+
+
 Compilation errors when EXCESS_ICE = TRUE
 
 	Files Affected:

--- a/src/write_forcing_file.c
+++ b/src/write_forcing_file.c
@@ -27,6 +27,7 @@ void write_forcing_file(atmos_data_struct *atmos,
   2008-Jun-10 Fixed typo in QAIR and REL_HUMID eqns.			TJB
   2009-Feb-22 Added OUT_VPD.						TJB
   2011-Nov-04 Added OUT_TSKC.						TJB
+  2014-Apr-02 Fixed uninitialized dummy variables.			TJB
 
 **********************************************************************/
 {
@@ -37,10 +38,10 @@ void write_forcing_file(atmos_data_struct *atmos,
   short int          *tmp_siptr;
   unsigned short int *tmp_usiptr;
   dmy_struct         *dummy_dmy;
-  int                 dummy_dt;
   int                 dt_sec;
 
   dt_sec = global_param.dt*SECPHOUR;
+  dummy_dmy = NULL;
 
   for ( rec = 0; rec < nrecs; rec++ ) {
     for ( j = 0; j < NF; j++ ) {
@@ -93,7 +94,7 @@ void write_forcing_file(atmos_data_struct *atmos,
           }
         }
       }
-      write_data(out_data_files, out_data, dummy_dmy, dummy_dt);
+      write_data(out_data_files, out_data, dummy_dmy, global_param.dt);
     }
   }
 


### PR DESCRIPTION
This fixes issue #113.

Fixed uninitialized dummy\* variables.  I tested this by running the code for the "pnw" test cells, for the following cases:
1. 24hwb, OUTPUT_FORCE=FALSE
2. 1heb, OUTPUT_FORCE=TRUE
I verified that the results were exactly the same as for VIC.4.1.2.k.

I also ran valgrind -v --leak-check=full and confirmed no errors resulting from this change.  However, I did find a memory leak in read_soilparam.c.  I will fix this next.
