### PR TITLE
Fixed memory leak in vicNl.c.

### DIFF
--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -33,6 +33,21 @@ Usage:
 Bug Fixes:
 ----------
 
+Fixed memory leak in vicNl()
+
+	Files Affected:
+
+	vicNl.c
+
+	Description:
+
+	Several soil_con arrays, allocated in read_soilparam(), were not being
+	freed in vicNl() due to the "free" statements being inside the wrong
+	OUTPUT_FORCE "if" block.  This has been fixed.
+
+
+
+
 Uninitialized variables in write_forcing_file().
 
 	Files Affected:

--- a/src/vicNl.c
+++ b/src/vicNl.c
@@ -92,6 +92,8 @@ int main(int argc, char *argv[])
 	      read_soilparam().						TJB
   2012-Jan-16 Removed LINK_DEBUG code					BN
   2014-Mar-24 Removed ARC_SOIL option         BN
+  2014-Apr-02 Moved "free" statements for soil_con arrays outside the
+	      OUTPUT_FORCE condition to avoid memory leak.		TJB
 **********************************************************************/
 {
 
@@ -366,14 +368,14 @@ int main(int argc, char *argv[])
 #endif /* QUICK_FS */
       free_dist_prcp(&prcp,veg_con[0].vegetat_type_num);
       free_vegcon(&veg_con);
+      free((char*)init_STILL_STORM);
+      free((char*)init_DRY_TIME);
+#endif /* !OUTPUT_FORCE */
       free((char *)soil_con.AreaFract);
       free((char *)soil_con.BandElev);
       free((char *)soil_con.Tfactor);
       free((char *)soil_con.Pfactor);
       free((char *)soil_con.AboveTreeLine);
-      free((char*)init_STILL_STORM);
-      free((char*)init_DRY_TIME);
-#endif /* !OUTPUT_FORCE */
     }	/* End Run Model Condition */
   } 	/* End Grid Loop */
 


### PR DESCRIPTION
This fixes issue #115.

The fix was simply to move some "free" statements in vicNl.c to outside of an OUTPUT_FORCE "if" block.

I tested this on the pnw test cells, for the following cases, confirming that the output is identical to 4.1.2.k:
1. 24hwb, OUTPUT_FORCE=FALSE
2. 1heb, OUTPUT_FORCE=TRUE.
I ran valgrind -v --leak-check=full for these cases to confirm that the memory leaks were gone.
