### PR TITLE
Fix for liquid soil moisture < 0 in some cases.

### DIFF
--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -26,6 +26,31 @@ Usage:
 
 
 --------------------------------------------------------------------------------
+***** Description of changes from VIC 4.1.2.l to VIC 4.1.2.m *****
+--------------------------------------------------------------------------------
+
+
+Bug Fixes:
+----------
+
+Fixed negative liquid soil moisture for bare soil conditions
+
+	Files Affected:
+
+	runoff.c
+
+	Description:
+
+	Previously, runoff() only checked whether total (liquid+ice) soil
+	moisture was > residual moisture, but not whether liquid soil moisture
+	was positive.  In some cases, in the bare soil tile, liquid soil moisture
+	could occasionally go negative.  This has been fixed by adding a check on
+	liquid soil moisture to runoff().
+
+
+
+
+--------------------------------------------------------------------------------
 ***** Description of changes from VIC 4.1.2.k to VIC 4.1.2.l *****
 --------------------------------------------------------------------------------
 

--- a/src/global.h
+++ b/src/global.h
@@ -20,7 +20,7 @@
 	      characteristics of bare soil.				TJB
   2012-Jan-16 Removed LINK_DEBUG code					BN
 **********************************************************************/
-char *version = "4.1.2.l bug fix update 2014-Apr-03";
+char *version = "4.1.2.m bug fix update 2014-May-15";
 
 char *optstring = "g:vo";
 

--- a/src/runoff.c
+++ b/src/runoff.c
@@ -166,6 +166,7 @@ int  runoff(cell_data_struct  *cell_wet,
   2011-Jun-03 Added options.ORGANIC_FRACT.  Soil properties now take
 	      organic fraction into account.					TJB
   2012-Jan-16 Removed LINK_DEBUG code						BN
+  2014-May-09 Added check on liquid soil moisture to ensure always >= 0.	TJB
 **********************************************************************/
 {  
   extern option_struct options;
@@ -593,6 +594,11 @@ int  runoff(cell_data_struct  *cell_wet,
 	      firstlayer=FALSE;
 	      
 	      /** verify that current layer moisture is greater than minimum **/
+	      if (liq[lindex] < 0) {
+		/** liquid cannot fall below 0 **/
+		Q12[lindex] += liq[lindex];
+		liq[lindex] = 0;
+	      }
 	      if ((liq[lindex]+ice[lindex]) < resid_moist[lindex]) {
 		/** moisture cannot fall below minimum **/
 		Q12[lindex] += (liq[lindex]+ice[lindex]) - resid_moist[lindex];


### PR DESCRIPTION
This fixes issue #123.

Tested the following cases:
1. 24h water balance mode, no bare soil: same result as VIC.4.1.2.l
2. 1h energy balance mode, no bare soil: same result as VIC.4.1.2.l
3. 24h water balance mode, bare soil present: fixed water balance errors
4. 1h energy balance mode + frozen soil, bare soil present: fixed water balance errors
