### PR TITLE
Fixed bug in reading state file when skipping cells.

### DIFF
--- a/src/read_initial_model_state.c
+++ b/src/read_initial_model_state.c
@@ -146,7 +146,6 @@ void read_initial_model_state(FILE                *init_state,
       // skip rest of current cells info
       fgets(tmpstr, MAXSTRING, init_state); // skip rest of general cell info
       for ( veg = 0; veg <= tmp_Nveg; veg++ ) {
-	fgets(tmpstr, MAXSTRING, init_state); // skip dist precip info
 	for ( band = 0; band < tmp_Nband; band++ )
 	  fgets(tmpstr, MAXSTRING, init_state); // skip snowband info
       }


### PR DESCRIPTION
When dist_prec was removed, I neglected to remove a related line in read_initial_model_state.c that assumes (when skipping over inactive cells) that dist_prec parameters occupy 1 line per veg tile in the state file.  This resulted in VIC not being able to read a state file if it had to skip inactive cells.  This has been fixed.
