### PR TITLE
Fix to division by 0 in runoff.c, plus minor change to evap logic for in...

### DIFF
--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -401,6 +401,32 @@ Removed the DIST_PRCP option.
 Bug Fixes:
 ----------
 
+Fixed division by 0 and nans in output when there is no liquid water available
+to satisfy evaporative demand
+
+	Files Affected:
+
+	runoff.c
+
+	Description:
+
+	Previously, runoff() scaled estimated evaporation for each frost subarea
+	by that subarea's portion of available liquid moisture, via summing
+	available liquid moisture over all subareas and computing the ratio of
+	each subarea's moisture to the sum.  There was no check on whether the
+	sum > 0, resulting in the possibility of division by 0 when no liquid
+	moisture is available.  This has been fixed (a check was added).  In
+	addition, the apportionment of evaporation to subareas originally
+	included a check on whether all of the evaporative demand was met,
+	with a warning statement if not.  This check and warning have been
+	removed, since the evaporation values are subsequently modified to
+	reflect what actually evaporated (i.e. it's ok for the initial
+	estimate to exceed available moisture without affecting the water
+	balance).
+
+
+
+
 Fixed negative liquid soil moisture for bare soil conditions
 
 	Files Affected:


### PR DESCRIPTION
...ternal consistency.  This not only addresses issue #138, but also addresses issue #145 (nans on develop branch), since fixing #138 also removed the nans.

Note: I also noticed small water balance errors.  These were present before the fix and are still present, i.e. the fix did not cause them.  It is possible that these errors are related to the same overall code change (i.e., errors associated with available moisture and the movement of SPATIAL_FROST from user_def.h option to run-time option).  Moving SPATIAL_FROST to run-time required making layer moisture, temperature, evap, etc. into arrays over the frost_subareas dimension and summing over this dimension for all water balance operations, even when SPATIAL_FROST is FALSE.
