### PR TITLE
 add print function to echo license boilerplate to stdout 

### DIFF
--- a/drivers/classic/src/display_current_settings.c
+++ b/drivers/classic/src/display_current_settings.c
@@ -27,6 +27,7 @@
 
 #include <vic_def.h>
 #include <vic_run.h>
+#include <vic_driver_classic.h>
 #include <vic_driver_shared.h>
 
 /******************************************************************************
@@ -43,15 +44,13 @@ display_current_settings(int mode)
 
     int                        file_num;
 
+    print_version(VIC_DRIVER);
+
     if (mode == DISP_VERSION) {
-        fprintf(stderr, "***** VIC Version %s *****\n", version);
         return;
     }
-    else {
-        fprintf(stderr,
-                "\n***** VIC Version %s - Current Model Settings *****\n",
-                version);
-    }
+
+    fprintf(stderr, "\nCurrent Model Settings\n");
 
     fprintf(stderr, "\n");
     fprintf(stderr, "COMPILE-TIME OPTIONS (set in .h files)\n");

--- a/drivers/image/include/vic_driver_image.h
+++ b/drivers/image/include/vic_driver_image.h
@@ -32,7 +32,7 @@
 #include <stdio.h>
 #include <vic_driver_shared.h>
 
-#define DRIVER "Image"
+#define VIC_DRIVER "Image"
 
 #define MAXDIMS 10
 

--- a/drivers/image/src/display_current_settings.c
+++ b/drivers/image/src/display_current_settings.c
@@ -43,15 +43,14 @@ display_current_settings(int mode)
 
     int                        file_num;
 
+
+    print_version(VIC_DRIVER);
+
     if (mode == DISP_VERSION) {
-        fprintf(stderr, "***** VIC Version %s *****\n", version);
         return;
     }
-    else {
-        fprintf(stderr,
-                "\n***** VIC Version %s - Current Model Settings *****\n",
-                version);
-    }
+
+    fprintf(stderr, "\nCurrent Model Settings\n");
 
     fprintf(stderr, "\n");
     fprintf(stderr, "COMPILE-TIME OPTIONS (set in .h files)\n");

--- a/drivers/shared/include/vic_driver_shared.h
+++ b/drivers/shared/include/vic_driver_shared.h
@@ -31,7 +31,8 @@
 #include <vic_def.h>
 #include <vic_physical_constants.h>
 
-#define version "5.0 beta 2014-Dec-03"
+#define VERSION "5.0 beta 2014-Dec-03"
+#define SHORT_VERSION "5.0.beta"
 
 /******************************************************************************
  * @brief    Stores forcing file input information.
@@ -100,6 +101,7 @@ void print_lake_con(lake_con_struct *lcon, size_t nlnodes);
 void print_lake_var(lake_var_struct *lvar, size_t nlnodes, size_t nfronts,
                     size_t nlayers, size_t nnodes, size_t nfrost, size_t npet);
 void print_layer_data(layer_data_struct *ldata, size_t nfrost);
+void print_license(void);
 void print_option(option_struct *option);
 void print_out_data(out_data_struct *out, size_t nelem);
 void print_out_data_file(out_data_file_struct *outf);
@@ -113,7 +115,8 @@ void print_veg_con(veg_con_struct *vcon, size_t nroots, char blowing, char lake,
                    char carbon, size_t ncanopy);
 void print_veg_lib(veg_lib_struct *vlib, char carbon);
 void print_veg_var(veg_var_struct *vvar, size_t ncanopy);
-void usage(char *);
+void print_version(char *);
+void print_usage(char *);
 void soil_moisture_from_water_table(soil_con_struct *soil_con, size_t nlayers);
 
 #endif

--- a/drivers/shared/src/cmd_proc.c
+++ b/drivers/shared/src/cmd_proc.c
@@ -48,7 +48,7 @@ cmd_proc(int    argc,
     int  optchar;
 
     if (argc == 1) {
-        usage(argv[0]);
+        print_usage(argv[0]);
         exit(1);
     }
 
@@ -73,7 +73,7 @@ cmd_proc(int    argc,
             break;
         default:
             /** Print Usage if Invalid Command Line Arguments **/
-            usage(argv[0]);
+            print_usage(argv[0]);
             exit(1);
             break;
         }
@@ -82,7 +82,7 @@ cmd_proc(int    argc,
     if (!GLOBAL_SET) {
         fprintf(stderr,
                 "ERROR: Must set global control file using the '-g' flag\n");
-        usage(argv[0]);
+        print_usage(argv[0]);
         exit(1);
     }
 }
@@ -91,7 +91,7 @@ cmd_proc(int    argc,
  * @brief    This routine prints out usage details.
  *****************************************************************************/
 void
-usage(char *executable)
+print_usage(char *executable)
 {
     fprintf(stderr,
             "Usage: %s [-v | -o | -g <global_parameter_file>]\n", executable);
@@ -108,4 +108,42 @@ usage(char *executable)
             "       parameters as well as model option flags, and the names"
             " and\n");
     fprintf(stderr, "       locations of all other files.\n");
+}
+
+/******************************************************************************
+ * @brief    This routine prints out the model Version
+ *****************************************************************************/
+void print_version(char *driver)
+{
+    fprintf(stderr, "  VIC Version : %s\n", SHORT_VERSION);
+    fprintf(stderr, "  VIC Driver  : %s\n", driver);
+
+    print_license();
+
+}
+
+/******************************************************************************
+ * @brief    This routine prints out license information
+ *****************************************************************************/
+void print_license()
+{
+
+ fprintf(stderr,
+         "\n  Variable Infiltration Capacity (VIC) macroscale hydrologic\n");
+ fprintf(stderr,
+         "  model version %s, Copyright (C) 2014 Land Surface\n",
+         SHORT_VERSION);
+ fprintf(stderr,
+         "  HydrologyGroup, Dept. of Civil and Environmental Engineering,\n");
+ fprintf(stderr,
+         "  University of Washington.  VIC comes with ABSOLUTELY NO\n");
+ fprintf(stderr,
+         "  WARRANTY. This is free software, you may redistribute it\n");
+ fprintf(stderr,
+         "  under certain conditions; see LICENSE.txt for details.\n\n");
+
+ fprintf(stderr,
+         "  Report Bugs to: https://github.com/UW-Hydro/VIC/issues\n");
+ fprintf(stderr,
+         "  VIC Users Email List:  vicadmin@hydro.washington.edu\n\n");
 }


### PR DESCRIPTION
I forgot to add this when we added the license to the repo (#133). This basically prints a mostly boilerplate WARRANTY and LICENSE statement when VIC is called from the command line. The GPL license encourages this addition so I put it together. If we don't want it, we can certainly disregard.
