### PR TITLE
Initialize log before first use in cmd_proc()

### DIFF
--- a/drivers/classic/src/vic_classic.c
+++ b/drivers/classic/src/vic_classic.c
@@ -78,11 +78,11 @@ main(int   argc,
     out_data_struct      *out_data;
     save_data_struct      save_data;
 
-    /** Read Model Options **/
-    cmd_proc(argc, argv, filenames.global);
-
     // Initialize Log Destination
     initialize_log();
+
+    /** Read Model Options **/
+    cmd_proc(argc, argv, filenames.global);
 
     // Initialize global structures
     initialize_options();

--- a/drivers/image/src/vic_image.c
+++ b/drivers/image/src/vic_image.c
@@ -63,6 +63,9 @@ int
 main(int    argc,
      char **argv)
 {
+    // Initialize Log Destination
+    initialize_log();
+
     // process command line arguments
     cmd_proc(argc, argv, filenames.global);
 


### PR DESCRIPTION
`LOG_DEST` is used in `cmd_proc()`, but is initialized in `initialize_log()`, which therefore has to come first. In `vic_classic.c` this is simply a reversal of the function calls. Also added `initialize_log()` to `vic_image.c`. Without this a call to `vic_classic -o` or `vic_image -o` exits with a seg fault.
