### PR TITLE
Added SHAREDPATH to clean in Makefiles

### DIFF
--- a/drivers/classic/Makefile
+++ b/drivers/classic/Makefile
@@ -208,7 +208,7 @@ full:
 	make model
 
 clean::
-	/bin/rm -f ${DRIVERPATH}/src/*.o ${VICPATH}/src/*.o core log ${DRIVERPATH}/src/*~ ${VICPATH}/src/*~ vic_classic
+	/bin/rm -f ${DRIVERPATH}/src/*.o ${SHAREDPATH}/src/*.o ${VICPATH}/src/*.o core log ${DRIVERPATH}/src/*~ ${SHAREDPATH}/src/*~ ${VICPATH}/src/*~ vic_classic
 
 model: $(OBJS)
 	$(CC) -o vic_classic$(EXT) $(OBJS) $(CFLAGS) $(LIBRARY)

--- a/drivers/image/Makefile
+++ b/drivers/image/Makefile
@@ -209,7 +209,7 @@ full:
 	make model
 
 clean::
-	/bin/rm -f ${DRIVERPATH}/src/*.o ${VICPATH}/src/*.o core log ${DRIVERPATH}/src/*~ ${VICPATH}/src/*~ vic_image
+	/bin/rm -f ${DRIVERPATH}/src/*.o ${SHAREDPATH}/src/*.o  ${VICPATH}/src/*.o core log ${DRIVERPATH}/src/*~ ${SHAREDPATH}/src/*.~ ${VICPATH}/src/*~ vic_image
 
 model: $(OBJS)
 	$(CC) -o vic_image$(EXT) $(OBJS) $(CFLAGS) $(LIBRARY)


### PR DESCRIPTION
The *.o and *~ files in the SHAREDPATH directory were not removed when 'make clean' was executed.
