### PR TITLE
fix log_ncerr macro

### DIFF
--- a/vic_run/include/vic_log.h
+++ b/vic_run/include/vic_log.h
@@ -67,7 +67,7 @@ void setup_logging(int id);
                                           exit(1); }
 
 #define clean_errno() (errno == 0 ? "None" : strerror(errno))
-#define clean_ncerrno(e) (errno == 0 ? "None" : nc_strerror(e))
+#define clean_ncerrno(e) (nc_strerror(e))
 
 #ifdef NO_LINENOS
 // versions that don't feature line numbers


### PR DESCRIPTION
`log_ncerr` now looks up the error message string and prints it, along with the file and line number.