### PR TITLE
Set log level at compile time

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -8,9 +8,9 @@ import argparse
 import datetime
 from collections import OrderedDict
 import string
-from vic import VIC, VIC_TestError, VIC_RuntimeError
-from vic.io import read_config, read_vic_ascii, read_configobj
-from vic.testing import check_completed, check_for_nans
+from tonic.models.vic.vic import VIC, VICRuntimeError, read_vic_ascii
+from tonic.io import read_config, read_configobj
+from tonic.testing import check_completed, check_for_nans, VICTestError
 
 OUTPUT_WIDTH = 100
 
@@ -76,7 +76,7 @@ class TestResults(object):
 
 
 # -------------------------------------------------------------------- #
-class VIC_ReturnCodeError(BaseException):
+class VICReturnCodeError(BaseException):
     pass
 # -------------------------------------------------------------------- #
 
@@ -144,7 +144,7 @@ def main():
     # Validate input directories
     for d in [data_dir, test_dir]:
         if not os.path.exists(d):
-            raise VIC_TestError('Directory: {0} does not exist'.format(d))
+            raise VICTestError('Directory: {0} does not exist'.format(d))
     # ---------------------------------------------------------------- #
 
     # ---------------------------------------------------------------- #
@@ -316,10 +316,10 @@ def run_system(config_file, vic_exe, test_dir, test_data_dir, out_dir):
 
             expectation = test_dict['expected_retval']
             if returncode != int(test_dict['expected_retval']):
-                raise VIC_ReturnCodeError('VIC return code ({0}) '
-                                          'does not match expected '
-                                          '({1})'.format(returncode,
-                                                         expectation))
+                raise VICReturnCodeError('VIC return code ({0}) '
+                                         'does not match expected '
+                                         '({1})'.format(returncode,
+                                                        expectation))
 
             # -------------------------------------------------------- #
             # check output files
@@ -351,13 +351,13 @@ def run_system(config_file, vic_exe, test_dir, test_data_dir, out_dir):
             # -------------------------------------------------------- #
 
         # Handle errors
-        except VIC_RuntimeError as e:
+        except VICRuntimeError as e:
             test_comment = 'Test failed during simulation'
             error_message = e
-        except VIC_TestError as e:
+        except VICTestError as e:
             test_comment = 'Test failed during testing of output files'
             error_message = e
-        except VIC_ReturnCodeError as e:
+        except VICReturnCodeError as e:
             test_comment = 'Test failed due to incorrect return code'
             error_message = e
 
@@ -462,8 +462,8 @@ def run_science(config_file, vic_exe, test_dir, test_data_dir, out_dir):
             test_complete = True
 
             if returncode != 0:
-                raise VIC_ReturnCodeError('VIC return code not equal to zero, '
-                                          'check VIC logs for test')
+                raise VICReturnCodeError('VIC return code not equal to zero, '
+                                         'check VIC logs for test')
 
             # -------------------------------------------------------- #
             # check output files
@@ -495,13 +495,13 @@ def run_science(config_file, vic_exe, test_dir, test_data_dir, out_dir):
             # -------------------------------------------------------- #
 
         # Handle errors
-        except VIC_RuntimeError as e:
+        except VICRuntimeError as e:
             test_comment = 'Test failed during simulation'
             error_message = e
-        except VIC_TestError as e:
+        except VICTestError as e:
             test_comment = 'Test failed during testing of output files'
             error_message = e
-        except VIC_ReturnCodeError as e:
+        except VICReturnCodeError as e:
             test_comment = 'Test failed due to incorrect return code'
             error_message = e
 
@@ -606,8 +606,8 @@ def run_examples(config_file, vic_exe, test_dir, test_data_dir, out_dir):
             test_complete = True
 
             if returncode != 0:
-                raise VIC_ReturnCodeError('VIC return code not equal to zero, '
-                                          'check VIC logs for test')
+                raise VICReturnCodeError('VIC return code not equal to zero, '
+                                         'check VIC logs for test')
 
             # -------------------------------------------------------- #
             # check output files
@@ -639,13 +639,13 @@ def run_examples(config_file, vic_exe, test_dir, test_data_dir, out_dir):
             # -------------------------------------------------------- #
 
         # Handle errors
-        except VIC_RuntimeError as e:
+        except VICRuntimeError as e:
             test_comment = 'Test failed during simulation'
             error_message = e
-        except VIC_TestError as e:
+        except VICTestError as e:
             test_comment = 'Test failed during testing of output files'
             error_message = e
-        except VIC_ReturnCodeError as e:
+        except VICReturnCodeError as e:
             test_comment = 'Test failed due to incorrect return code'
             error_message = e
 

--- a/vic/drivers/classic/Makefile
+++ b/vic/drivers/classic/Makefile
@@ -65,7 +65,7 @@ CFLAGS  =  ${INCLUDES} -g -Wall -Wextra
 #LIBRARY = -lm -lefence -L/usr/local/lib
 
 # Set the log level
-# To turn off warning statments, set LOG_LVL >= 30
+# To turn off warning statements, set LOG_LVL >= 30
 # | Level     | Numeric value    |
 # |---------  |---------------   |
 # | ERROR     | Always Active    |

--- a/vic/drivers/classic/Makefile
+++ b/vic/drivers/classic/Makefile
@@ -64,6 +64,9 @@ CFLAGS  =  ${INCLUDES} -g -Wall -Wextra
 #CFLAGS  = ${INCLUDES} -g -Wall -Wno-unused
 #LIBRARY = -lm -lefence -L/usr/local/lib
 
+# Set VIC logging level
+LOG_LVL = 0
+
 # -----------------------------------------------------------------------
 # MOST USERS DO NOT NEED TO MODIFY BELOW THIS LINE
 # -----------------------------------------------------------------------
@@ -233,7 +236,7 @@ clean::
 # -------------------------------------------------------------
 depend: .depend
 .depend: $(SRCS) $(HDRS)
-	$(CC) $(CFLAGS) -M $(SRCS) > $@
+	$(CC) $(CFLAGS) -M $(SRCS) -DLOG_LVL=$(LOG_LVL) > $@
 
 clean::
 	\rm -f .depend

--- a/vic/drivers/classic/Makefile
+++ b/vic/drivers/classic/Makefile
@@ -64,8 +64,15 @@ CFLAGS  =  ${INCLUDES} -g -Wall -Wextra
 #CFLAGS  = ${INCLUDES} -g -Wall -Wno-unused
 #LIBRARY = -lm -lefence -L/usr/local/lib
 
-# Set VIC logging level
-LOG_LVL = 0
+# Set the log level
+# To turn off warning statments, set LOG_LVL >= 30
+# | Level     | Numeric value    |
+# |---------  |---------------   |
+# | ERROR     | Always Active    |
+# | WARNING   | < 30             |
+# | INFO      | < 20             |
+# | DEBUG     | < 10             |
+LOG_LVL = 5
 
 # -----------------------------------------------------------------------
 # MOST USERS DO NOT NEED TO MODIFY BELOW THIS LINE

--- a/vic/drivers/image/Makefile
+++ b/vic/drivers/image/Makefile
@@ -84,6 +84,9 @@ CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra
 #CFLAGS  = ${INCLUDES} -g -Wall -Wno-unused
 #LIBRARY = -lm -lefence -L/usr/local/lib
 
+# Set VIC logging level
+LOG_LVL = 0
+
 # -----------------------------------------------------------------------
 # MOST USERS DO NOT NEED TO MODIFY BELOW THIS LINE
 # -----------------------------------------------------------------------
@@ -245,7 +248,7 @@ clean::
 # -------------------------------------------------------------
 depend: .depend
 .depend: $(SRCS) $(HDRS)
-	$(CC) $(CFLAGS) -M $(SRCS) > $@
+	$(CC) $(CFLAGS) -M $(SRCS) -DLOG_LVL=$(LOG_LVL) > $@
 
 clean::
 	\rm -f .depend

--- a/vic/drivers/image/Makefile
+++ b/vic/drivers/image/Makefile
@@ -84,8 +84,15 @@ CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra
 #CFLAGS  = ${INCLUDES} -g -Wall -Wno-unused
 #LIBRARY = -lm -lefence -L/usr/local/lib
 
-# Set VIC logging level
-LOG_LVL = 0
+# Set the log level
+# To turn off warning statments, set LOG_LVL >= 30
+# | Level     | Numeric value    |
+# |---------  |---------------   |
+# | ERROR     | Always Active    |
+# | WARNING   | < 30             |
+# | INFO      | < 20             |
+# | DEBUG     | < 10             |
+LOG_LVL = 5
 
 # -----------------------------------------------------------------------
 # MOST USERS DO NOT NEED TO MODIFY BELOW THIS LINE

--- a/vic/drivers/image/Makefile
+++ b/vic/drivers/image/Makefile
@@ -85,7 +85,7 @@ CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra
 #LIBRARY = -lm -lefence -L/usr/local/lib
 
 # Set the log level
-# To turn off warning statments, set LOG_LVL >= 30
+# To turn off warning statements, set LOG_LVL >= 30
 # | Level     | Numeric value    |
 # |---------  |---------------   |
 # | ERROR     | Always Active    |

--- a/vic/vic_run/include/vic_log.h
+++ b/vic/vic_run/include/vic_log.h
@@ -70,29 +70,28 @@ void setup_logging(int id);
 #define clean_ncerrno(e) (nc_strerror(e))
 
 // Debug Level
-#if LOG_LVL >= 10
-#define debug(M, ...)
-#else
+#if LOG_LVL < 10
 #define debug(M, ...) fprintf(LOG_DEST, "[DEBUG] %s:%d: " M "\n", __FILE__, \
                               __LINE__, ## __VA_ARGS__)
+#else
+#define debug(M, ...)
+
 #endif
 
 // Info Level
-#if LOG_LVL >= 20
-#define log_info(M, ...)
-#else
+#if LOG_LVL < 20
 #ifdef NO_LINENOS
 #define log_info(M, ...) fprintf(LOG_DEST, "[INFO] " M "\n", ## __VA_ARGS__)
 #else
 #define log_info(M, ...) fprintf(LOG_DEST, "[INFO] %s:%d: " M "\n", __FILE__, \
                                  __LINE__, ## __VA_ARGS__)
 #endif
+#else
+#define log_info(M, ...)
 #endif
 
 // Warn Level
-#if LOG_LVL >= 30
-#define log_warn(M, ...)
-#else
+#if LOG_LVL < 30
 #ifdef NO_LINENOS
 #define log_warn(M, ...) fprintf(LOG_DEST, "[WARN] errno: %s: " M "\n", \
                                  clean_errno(), ## __VA_ARGS__); errno = 0
@@ -101,6 +100,9 @@ void setup_logging(int id);
                                  __FILE__, __LINE__, \
                                  clean_errno(), ## __VA_ARGS__); errno = 0
 #endif
+#else
+#define log_warn(M, ...)
+
 #endif
 
 // Error Level is always active

--- a/vic/vic_run/include/vic_log.h
+++ b/vic/vic_run/include/vic_log.h
@@ -46,16 +46,15 @@
 #include <string.h>
 
 // Set the log level
-// To turn off debug statments, set LOG_LVL > 10
+// To turn off warning statments, set LOG_LVL >= 30
 // | Level     | Numeric value    |
 // |---------  |---------------   |
-// | ERROR     | 40               | > 40 will raise a compile time error
-// | WARNING   | 30               |
-// | INFO      | 20               |
-// | DEBUG     | 10               |
-// | NOTSET    | 0                |
+// | ERROR     | Always Active    |
+// | WARNING   | < 30             |
+// | INFO      | < 20             |
+// | DEBUG     | < 10             |
 #ifndef LOG_LVL
-#define LOG_LVL 0
+#define LOG_LVL 25
 #endif
 
 FILE *LOG_DEST;
@@ -71,7 +70,7 @@ void setup_logging(int id);
 #define clean_ncerrno(e) (nc_strerror(e))
 
 // Debug Level
-#if LOG_LVL > 10
+#if LOG_LVL >= 10
 #define debug(M, ...)
 #else
 #define debug(M, ...) fprintf(LOG_DEST, "[DEBUG] %s:%d: " M "\n", __FILE__, \
@@ -79,7 +78,7 @@ void setup_logging(int id);
 #endif
 
 // Info Level
-#if LOG_LVL > 20
+#if LOG_LVL >= 20
 #define log_info(M, ...)
 #else
 #ifdef NO_LINENOS
@@ -91,7 +90,7 @@ void setup_logging(int id);
 #endif
 
 // Warn Level
-#if LOG_LVL > 30
+#if LOG_LVL >= 30
 #define log_warn(M, ...)
 #else
 #ifdef NO_LINENOS
@@ -104,11 +103,7 @@ void setup_logging(int id);
 #endif
 #endif
 
-// Error Level
-#if LOG_LVL > 40
-// Make sure we still raise an exit code
-#error "VIC Compile Time Error: LOG_LVL is set such that error messages will not be printed, however errors will still be raised"
-#else
+// Error Level is always active
 #ifdef NO_LINENOS
 #define log_err(M, ...) fprintf(LOG_DEST, "[ERROR] errno: %s: " M "\n", \
                                 clean_errno(), ## __VA_ARGS__); exit(1);
@@ -120,7 +115,6 @@ void setup_logging(int id);
                                 clean_errno(), ## __VA_ARGS__); exit(1);
 #define log_ncerr(e) fprintf(LOG_DEST, "[ERROR] %s:%d: errno: %s \n", __FILE__, \
                              __LINE__, clean_ncerrno(e)); exit(1);
-#endif
 #endif
 
 // These depend on previously defined macros


### PR DESCRIPTION
This PR allows for the compile time setting of the logging level in VIC. Level options are:

| Level     | Numeric value    |
|---------  |---------------   |
| ERROR     | 40               | 
| WARNING   | 30               |
| INFO      | 20               |
| DEBUG     | 10               |
| NOTSET    | 0                |

These options match those in the [Python logging module](https://docs.python.org/2/library/logging.html#logging-levels).

To turn off `DEBUG` logging, the user sets `LOG_LVL > 10`.  This PR does not allow turning off the Error level logging and will raise an error during compilation.

closes #218