### PR TITLE
resolve master merge conflicts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+VIC is Open Source software. This means that the code is made available for free, but also that development, maintenance and support need to be community efforts. Our rationale for moving the VIC model development to the open source community is that we want:
+
+- to encourage other researchers and developers to contribute to VIC development, and
+- to facilitate transparent development and use of the model.
+
+## Support
+
+There is no official support for the VIC model, other than the VIC documentation, the VIC source code archive and the description of the model in the literature. Any additional support relies on volunteer efforts by the  VIC development community, which means that no one is being paid to provide VIC support. The following resources are available:
+
+- [VIC Source code repository](https://github.com/UW-Hydro/VIC) : Source code distribution, coordination of model development, bug fixes, and releases.
+- [VIC documentation](http://vic.readthedocs.org) at readthedocs.org.
+
+We expect that the user comes prepared with some understanding of the model and scientific computing. As such, these items are specifically not supported by the VIC development community:
+
+- Building and running the VIC model on platforms other than LINUX, UNIX, and OSX.
+- Using LINUX, UNIX, or OSX operating systems.
+- Development of project specific features.
+- Configuring individual model applications.
+
+## Getting In-touch
+
+The VIC user and developer community is quite large and is spread all around the world.  Depending on the question or issue your facing, there are a number of avenues to get in-touch:
+
+VIC Users Listserv: [![VIC Users Listserv](https://img.shields.io/badge/VIC%20Users%20Listserve-Active-blue.svg)](https://mailman.u.washington.edu/mailman/listinfo/vic_users)
+
+Developers Gitter Room: [![Join the chat at https://gitter.im/UW-Hydro/VIC](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/UW-Hydro/VIC?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+VIC Github Issues [![GitHub issues](https://img.shields.io/github/issues/UW-Hydro/VIC.svg)](https://github.com/UW-Hydro/VIC/issues)
+
+## Submitting Issues
+#### Submitting Bug Reports
+
+If you think you have found a bug in VIC, please file an issue on Github [here](https://github.com/UW-Hydro/VIC/issues). Please include the following information in your bug report:
+
+- Version of VIC that you are using (e.g. VIC.4.2.b)
+- Name and version of the C compiler you are using
+- Operating system
+- A description of relevant model settings
+- A summary of the bug or error message you are getting
+
+If you can provide more information that is great. If you know how to run the model in a debugger, you may be able to pinpoint where the problem occurs.
+
+#### Requesting New features
+
+The VIC model is under active development.  If you would like to propose a new feature, driver, or extension to the VIC model, please raise a Github issue [here](https://github.com/UW-Hydro/VIC/issues). Also, because VIC is an open source model with no official support for development, be prepared to contribute to the implementation of your feature request. Also note that features that are only of interest to you are unlikely to be implemented in the main source code repo (although you are of course free to modify the code in any way you see fit).
+
+## Contributing to VIC
+#### Git Workflow
+We have developed some documentation to help you get started if you are new to Git but want to contribute to VIC:
+
+- [Working with Git](http://vic.readthedocs.org/en/latest/Development/working-with-git/)
+- [Git Workflow](http://vic.readthedocs.org/en/latest/Development/git-workflow/)
+
+#### Style Guide
+To be added soon.  For now, please remember to comment your code well and [use `uncrustify` to format your code properly](https://github.com/UW-Hydro/VIC/tree/master/tools/code_format).

--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,65 @@ Usage:
 
 
 
+-------------------------------------------------------------------------------
+***** Description of changes between VIC 4.2.a and VIC 4.2.b *****
+-------------------------------------------------------------------------------
+
+Bug Fixes:
+----------
+
+Fixed memory error in initialize atmos when OUTPUT_FORCE = TRUE.
+
+	Files Affected:
+
+	initialize_atmos.
+	Makefile
+
+	Description:
+
+	Previously, access to unitialized elements of the veg_con and veg_hist
+	structure was attempted when OUTPUT_FORCE = TRUE, causing a memory error
+	and the model to crash.  This fix sets these elements inside a
+	`if (!options.OUTPUT_FORCE)` block allowing the OUTPUT_FORCE option to
+	work as expected.
+
+
+-------------------------------------------------------------------------------
+***** Description of changes between VIC 4.2 and VIC 4.2.a *****
+-------------------------------------------------------------------------------
+
+Bug Fixes:
+----------
+
+Fixed unitialized bare soil albedo.
+
+	Files Affected:
+
+	full_energy.c
+
+	Description:
+
+	Previously, bare_albedo was unset for the bare soil case (`iveg!=Nveg`).
+	This fix sets the bare_albedo to the global variable value of
+	`BARE_SOIL_ALBEDO`.
+
+
+
+Cleanup of frozen soil option constraints.
+
+	Files Affected:
+
+	calc_surf_energy_bal.c
+	get_global_param.c
+
+	Description:
+
+	Removed hardcoded, behind the scenes checks for the `EXP_TRANS` and
+	`NO_FLUX` global parameter values for case of `QUICK_SOLVE=TRUE` in
+	`calc_surf_energy_bal`.
+
+
+
 --------------------------------------------------------------------------------
 ***** Description of changes between VIC 4.1.2 and VIC 4.2 *****
 --------------------------------------------------------------------------------

--- a/readme.md
+++ b/readme.md
@@ -20,5 +20,5 @@ If you make use of this model, please acknowledge the appropriate references lis
 (http://www.hydro.washington.edu/Lettenmaier/Models/VIC/Documentation/References.shtml).
 
 If you want to contact us directly about the VIC model, you can send
-e-mail to `vicadmin at hydro.washington.edu`. Please include "VIC Model" in the subject line.
+e-mail to `vic_users at u.washington.edu`. Please include "VIC Model" in the subject line.
 


### PR DESCRIPTION
This branch resolves a few merge conflicts that have piled up while we've been working on VIC.5.  Because I have been manually porting changes to the develop branch all along, the merge was done using the "ours" rule: `VIC (feature/resolve_master_merge_conflicts)$ git merge upstream/master --strategy-option ours`.

This will allow us to merge the docs into `develop` here shortly as well as merge `develop` back into `master` when 5.0 is ready to release.

There were no code changes here so we can merge this as soon as the travis build passes.