### PR TITLE
set log level in setup.py

### DIFF
--- a/vic/drivers/python/setup.py
+++ b/vic/drivers/python/setup.py
@@ -12,9 +12,15 @@ import shutil
 from setuptools import setup, find_packages, Command
 from setuptools.extension import Extension
 
-# set log level here
+# Set the log level
+# To turn off warning statements, set LOG_LVL >= 30
+# | Level     | Numeric value    |
+# |---------  |---------------   |
+# | ERROR     | Always Active    |
+# | WARNING   | < 30             |
+# | INFO      | < 20             |
+# | DEBUG     | < 10             |
 log_level = 0
-
 
 MAJOR = 5
 MINOR = 0

--- a/vic/drivers/python/setup.py
+++ b/vic/drivers/python/setup.py
@@ -12,6 +12,10 @@ import shutil
 from setuptools import setup, find_packages, Command
 from setuptools.extension import Extension
 
+# set log level here
+log_level = 0
+
+
 MAJOR = 5
 MINOR = 0
 MICRO = 0
@@ -147,7 +151,8 @@ ext_obj = ext_name + sysconfig.get_config_var('SO')
 ext_module = Extension(ext_name,
                        sources=sources,
                        include_dirs=includes,
-                       extra_compile_args=['-std=c99'])
+                       extra_compile_args=['-std=c99',
+                                           '-DLOG_LVL={0}'.format(log_level)])
 
 # -------------------------------------------------------------------- #
 # Run Setup


### PR DESCRIPTION
This allows us to control the logging in the python driver from setup.py.  It is currently set low (0), since all we do with the python driver is unit tests and py.test filters standard out if an exception isn't raised.