### PR TITLE
Run uncrustify over all sources

### DIFF
--- a/tools/code_format/run_uncrustify.bash
+++ b/tools/code_format/run_uncrustify.bash
@@ -2,5 +2,5 @@
 
 # Run uncrustify on all VIC source files
 
-files=`find ../../drivers ../../vic_run -name '*.c' -o -name '*.h'`
+files=`find ../../vic -name '*.c' -o -name '*.h'`
 uncrustify -c uncrustify_VIC_c.cfg -l C --replace --no-backup $files

--- a/vic/drivers/classic/src/initialize_atmos.c
+++ b/vic/drivers/classic/src/initialize_atmos.c
@@ -837,6 +837,7 @@ initialize_atmos(atmos_data_struct    *atmos,
             }
             param_set.TYPE[VP].SUPPLIED = param_set.TYPE[QAIR].SUPPLIED;
         }
+
         /*************************************************
            If provided, translate relative humidity and air temperature
            into vapor pressure

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -123,7 +123,7 @@ main(int    argc,
 
         // if save: TBD needs to be fixed - not working in MPI
         // if (current == global_param.nrecs - 1) {
-        //    vic_store();
+        // vic_store();
         // }
     }
 

--- a/vic/drivers/image/src/vic_init_output.c
+++ b/vic/drivers/image/src/vic_init_output.c
@@ -68,7 +68,7 @@ vic_init_output(void)
         // open the netcdf history file
         initialize_history_file(&nc_hist_file);
     }
-    
+
     // broadcast which variables to write.
     for (i = 0; i < N_OUTVAR_TYPES; i++) {
         status = MPI_Bcast(&out_data[0][i].write, 1, MPI_C_BOOL,
@@ -77,8 +77,8 @@ vic_init_output(void)
             log_err("MPI error in vic_init_output(): %d\n", status);
         }
     }
-    
-    // broadcast history file info. Only the master process will write to it, 
+
+    // broadcast history file info. Only the master process will write to it,
     // but the slave processes need some of the information to initialize as
     // well (particularly which variables to write and dimension sizes)
     status = MPI_Bcast(&nc_hist_file, 1, mpi_nc_file_struct_type,
@@ -86,10 +86,9 @@ vic_init_output(void)
     if (status != MPI_SUCCESS) {
         log_err("MPI error in vic_init_output(): %d\n", status);
     }
-  
+
     // initialize netcdf info for output variables
     vic_nc_info(&nc_hist_file, out_data, nc_vars);
-
 }
 
 /******************************************************************************

--- a/vic/drivers/image/src/vic_mpi_support.c
+++ b/vic/drivers/image/src/vic_mpi_support.c
@@ -544,7 +544,6 @@ create_MPI_nc_file_struct_type(MPI_Datatype *mpi_type)
     free(mpi_types);
 }
 
-
 /******************************************************************************
  * @brief   Create an MPI_Datatype that represents the option_struct
  * @details This allows MPI operations in which the entire option_struct can
@@ -2063,41 +2062,41 @@ get_scatter_nc_field_int(char   *nc_name,
 #include <vic_driver_shared.h>
 #include <assert.h>
 
-//size_t              NF, NR;
-//size_t              current;
-size_t             *filter_active_cells = NULL;
-size_t             *mpi_map_mapping_array = NULL;
-//all_vars_struct    *all_vars = NULL;
-//atmos_data_struct  *atmos = NULL;
-//dmy_struct         *dmy = NULL;
-filenames_struct    filenames;
-filep_struct        filep;
-domain_struct       global_domain;
-domain_struct       local_domain;
-//global_param_struct global_param;
-//lake_con_struct     lake_con;
-MPI_Datatype        mpi_global_struct_type;
-MPI_Datatype        mpi_location_struct_type;
-MPI_Datatype        mpi_nc_file_struct_type;
-MPI_Datatype        mpi_option_struct_type;
-MPI_Datatype        mpi_param_struct_type;
-int                *mpi_map_local_array_sizes = NULL;
-int                *mpi_map_global_array_offsets = NULL;
-int                 mpi_rank;
-int                 mpi_size;
-//nc_file_struct      nc_hist_file;
-//nc_var_struct       nc_vars[N_OUTVAR_TYPES];
-//option_struct       options;
-//parameters_struct   param;
-//out_data_struct   **out_data;
-//save_data_struct   *save_data;
-//param_set_struct    param_set;
-//soil_con_struct    *soil_con = NULL;
-//veg_con_map_struct *veg_con_map = NULL;
-//veg_con_struct    **veg_con = NULL;
-//veg_hist_struct   **veg_hist = NULL;
-//veg_lib_struct    **veg_lib = NULL;
-FILE            *LOG_DEST;
+// size_t              NF, NR;
+// size_t              current;
+size_t *filter_active_cells = NULL;
+size_t *mpi_map_mapping_array = NULL;
+// all_vars_struct    *all_vars = NULL;
+// atmos_data_struct  *atmos = NULL;
+// dmy_struct         *dmy = NULL;
+filenames_struct filenames;
+filep_struct     filep;
+domain_struct    global_domain;
+domain_struct    local_domain;
+// global_param_struct global_param;
+// lake_con_struct     lake_con;
+MPI_Datatype     mpi_global_struct_type;
+MPI_Datatype     mpi_location_struct_type;
+MPI_Datatype     mpi_nc_file_struct_type;
+MPI_Datatype     mpi_option_struct_type;
+MPI_Datatype     mpi_param_struct_type;
+int             *mpi_map_local_array_sizes = NULL;
+int             *mpi_map_global_array_offsets = NULL;
+int              mpi_rank;
+int              mpi_size;
+// nc_file_struct      nc_hist_file;
+// nc_var_struct       nc_vars[N_OUTVAR_TYPES];
+// option_struct       options;
+// parameters_struct   param;
+// out_data_struct   **out_data;
+// save_data_struct   *save_data;
+// param_set_struct    param_set;
+// soil_con_struct    *soil_con = NULL;
+// veg_con_map_struct *veg_con_map = NULL;
+// veg_con_struct    **veg_con = NULL;
+// veg_hist_struct   **veg_hist = NULL;
+// veg_lib_struct    **veg_lib = NULL;
+FILE *LOG_DEST;
 
 /******************************************************************************
  * @brief   Test routine for VIC MPI support functions
@@ -2113,7 +2112,6 @@ int
 main(int    argc,
      char **argv)
 {
-
     int                 status;
     global_param_struct global;
     location_struct     location;
@@ -2210,13 +2208,13 @@ main(int    argc,
         log_err("MPI error in main(): %d\n", status);
     }
 
-    // assert the values on all processes are the same as the original 
+    // assert the values on all processes are the same as the original
     // assignment
     printf("%d: global.forceskip == %d\n", mpi_rank, global.forceskip[0]);
     assert(global.forceskip[0] == 4321);
     printf("%d: global.forceskip == %d\n", mpi_rank, global.forceskip[1]);
     assert(global.forceskip[1] == 8765);
-    printf("%d: global.time_origin_num == %f\n", mpi_rank, 
+    printf("%d: global.time_origin_num == %f\n", mpi_rank,
            global.time_origin_num);
     assert(global.time_origin_num == -12345.6789);
     printf("%d: location.latitude == %f\n", mpi_rank, location.latitude);

--- a/vic/vic_run/include/vic_def.h
+++ b/vic/vic_run/include/vic_def.h
@@ -746,7 +746,7 @@ typedef struct {
     unsigned short int endyear;    /**< Last year of model simulation */
     unsigned short int forceday[2];  /**< day forcing files starts */
     unsigned int forcesec[2];          /**< seconds since midnight when forcing
-                                      files starts */
+                                          files starts */
     unsigned short int forcemonth[2];  /**< month forcing files starts */
     unsigned short int forceoffset[2];  /**< counter to keep track of offset in reading
                                            forcing files; updated after every read */

--- a/vic/vic_run/src/interpoloation.c
+++ b/vic/vic_run/src/interpoloation.c
@@ -39,4 +39,3 @@ linear_interp(double x,
 {
     return((x - lx) / (ux - lx) * (uy - ly) + ly);
 }
-


### PR DESCRIPTION
Uncrustify was missed on a few recent PRs.  This fixes a few lines and updates the helper script to include the new VIC source file paths.