### PR TITLE
fix zero dim array error raised by PGI compilers

### DIFF
--- a/vic/vic_run/include/vic_def.h
+++ b/vic/vic_run/include/vic_def.h
@@ -64,13 +64,13 @@
 #define MAX_SUBDAILY_STEPS_PER_DAY  1440
 
 /***** Potential Evap types *****/
-#define N_PET_TYPES 0
-#define N_PET_TYPES_NON_NAT 0
+#define N_PET_TYPES 6
+#define N_PET_TYPES_NON_NAT 4
 #define PET_SATSOIL 0
 #define PET_H2OSURF 1
 #define PET_SHORT   2
 #define PET_TALL    3
-#define N_PET_TYPES_NAT 0
+#define N_PET_TYPES_NAT 2
 #define PET_NATVEG  4
 #define PET_VEGNOCR 5
 


### PR DESCRIPTION
The curse of the dreaded PET code! 

This fixes build in classic and cesm drivers.  @bartnijssen - do you remember why these vars were set to zero?