### PR TITLE
Debugging CESM driver

### DIFF
--- a/tests/unit/shared/test_vic_log.py
+++ b/tests/unit/shared/test_vic_log.py
@@ -9,7 +9,6 @@ def test_finalize_logging():
     assert vic_lib.finalize_logging() is None
 
 
-@pytest.mark.xfail
 def test_get_current_datetime():
     dts = ffi.new('char [2048]')
     assert len(ffi.string(dts)) == 0
@@ -17,7 +16,7 @@ def test_get_current_datetime():
     assert len(ffi.string(dts)) == 14
     now = datetime.datetime.now()
     now_string = now.strftime('%Y%m%d')
-    assert now_string == dts[:8]
+    assert now_string == ffi.string(dts)[:8].decode()
 
 
 def test_get_logname():

--- a/vic/drivers/cesm/bld/build_vic_namelist
+++ b/vic/drivers/cesm/bld/build_vic_namelist
@@ -29,6 +29,7 @@ def main():
         rundir = os.environ['RUNDIR']
         runtype = os.environ['RUN_TYPE']
         coderoot = os.environ['CODEROOT']
+        casedocs = os.environ['docdir']
     except KeyError as e:
         print('KeyError was raised accessing CESM environment variables')
         raise(e)
@@ -61,7 +62,7 @@ def main():
         grid_config[key] = copy_to_vicconf(coderoot, confdir, grid_config[key])
 
     # copy Constants and Global Parameters to RUNDIR
-    copy_to_rundir(grid_config, caseid, rundir, casebld)
+    copy_to_rundir(grid_config, caseid, rundir, casedocs)
 
     # write input files list
     dst_file = os.path.join(casebld, 'vic.input_data_list')
@@ -74,11 +75,12 @@ def main():
     set_readonly(dst_file)
 
 
-def copy_to_rundir(grid_config, caseid, rundir, casebld):
+def copy_to_rundir(grid_config, caseid, rundir, casedocs):
     for filekey, header_txt in [('vic_constants', 'Constants'),
                                 ('vic_global_param', 'Global Parameters')]:
         header = header_template.format(header_txt, caseid)
-        dst_file = os.path.join(rundir, os.path.basename(grid_config[filekey]))
+        fname = os.path.basename(grid_config[filekey])
+        dst_file = os.path.join(rundir, fname)
 
         # if file exists so add temporarily write permissions
         if os.path.isfile(dst_file):
@@ -87,6 +89,7 @@ def copy_to_rundir(grid_config, caseid, rundir, casebld):
         # copy file
         copy_clean_vic_config(grid_config[filekey], dst_file,
                               header=header, rundir=rundir, **grid_config)
+        shutil.copy(dst_file, os.path.join(casedocs, fname))
 
         # update the grid config
         grid_config[filekey] = dst_file

--- a/vic/drivers/cesm/bld/vic.globalconfig.txt
+++ b/vic/drivers/cesm/bld/vic.globalconfig.txt
@@ -1,8 +1,6 @@
 # VIC Global Configuration File
 
 NODES                  50
-SNOW_STEPS_PER_DAY     72
-RUNOFF_STEPS_PER_DAY   72
 OUT_TIME_UNITS         DAYS
 
 # Soil Temperature Options
@@ -39,16 +37,14 @@ RC_MODE              RC_JARVIS
 # Input Files and PATHS
 CONSTANTS        {vic_constants}
 DOMAIN           {vic_domain}
-LOG_DIR          {rundir}
+LOG_DIR          {rundir}/
 SOIL             {vic_params}
 VEGPARAM         {vic_params}
 VEGPARAM_LAI     TRUE
 LAI_SRC          LAI_FROM_VEGPARAM
 VEGLIB           {vic_params}
-SNOW_BAND        {vic_params}
-RESULT_DIR       {rundir}
-
-OUTPUT_STEPS_PER_DAY 24
+SNOW_BAND        1
+RESULT_DIR       {rundir}/
 
 N_OUTFILES  1
 OUTFILE     fluxes 21

--- a/vic/drivers/cesm/bld/vic.inputfiles.cfg
+++ b/vic/drivers/cesm/bld/vic.inputfiles.cfg
@@ -1,5 +1,5 @@
 [wr50a]
-vic_domain = ${DIN_LOC_ROOT}/lnd/vic/griddata/fracdata_wr50a_ar9v4_101013.nc
+vic_domain = ${DIN_LOC_ROOT}/share/domains/domain.lnd.wr50a_ar9v4.100920.nc
 vic_params = ${VIC5TESTDIR}/vic_params_wr50a_vic5.0.dev.nc
 vic_global_param = vic.globalconfig.txt
 vic_constants = vic.parameters.txt

--- a/vic/drivers/cesm/include/vic_cesm_def.h
+++ b/vic/drivers/cesm/include/vic_cesm_def.h
@@ -154,6 +154,20 @@ typedef struct {
 
 
 /******************************************************************************
+ * @brief   This structure stores clock information. See also ESMF_Clock.
+ *          Order is important and any changes here must be echoed in
+ *          vic_cesm_def_mod_f.F90
+ *****************************************************************************/
+typedef struct {
+    char caseid[MAXSTRING];
+    char casedesc[MAXSTRING];
+    char starttype[MAXSTRING];
+    char model_version[MAXSTRING];
+    char hostname[MAXSTRING];
+    char username[MAXSTRING];
+} case_metadata;
+
+/******************************************************************************
  * @brief   This structure is a c type container for the x2l fields.
  *          Order is important and any changes here must be echoed in
  *          vic_cesm_def_mod_f.F90

--- a/vic/drivers/cesm/include/vic_driver_cesm.h
+++ b/vic/drivers/cesm/include/vic_driver_cesm.h
@@ -68,9 +68,11 @@ void initialize_soil_con(soil_con_struct *soil_con);
 void initialize_state_file(nc_file_struct *nc);
 void initialize_veg_con(veg_con_struct *veg_con);
 void initialize_x2l_data(void);
+void make_dummy_forcings(x2l_data_struct *x2l);
 FILE *open_file(char *string, char *type);
 int parse_output_info(FILE *gp, out_data_struct **out_data);
 void print_atmos_data(atmos_data_struct *atmos);
+void print_case_metadata(case_metadata *cmeta);
 void print_domain(domain_struct *domain, bool print_loc);
 void print_l2x_data(l2x_data_struct *l2x);
 void print_location(location_struct *location);
@@ -89,12 +91,12 @@ double q_to_vp(double q, double p);
 void read_rpointer_file(char *fname);
 void sprint_location(char *str, location_struct *loc);
 unsigned short int start_type_from_char(char *start_str);
+char *trim(char *str);
 void vic_alloc(void);
 int vic_cesm_init_mpi(int MPI_COMM_VIC_F);
-int vic_cesm_init(char *vic_global_param_file, char *caseid, char *runtype,
-                  vic_clock vclock);
+int vic_cesm_init(vic_clock *vclock, case_metadata *cmeta);
 int vic_cesm_final(void);
-int vic_cesm_run(vic_clock vclock);
+int vic_cesm_run(vic_clock *vclock);
 void vic_nc_info(nc_file_struct *nc_hist_file, out_data_struct **out_data,
                  nc_var_struct *nc_vars);
 void vic_finalize(void);
@@ -104,7 +106,7 @@ void vic_cesm_run_model(void);
 void vic_init(void);
 void vic_init_output(void);
 void vic_restore(char *runtype_str);
-void vic_start(void);
+void vic_start(vic_clock *vclock, case_metadata *cmeta);
 void vic_store(void);
 void vic_write(void);
 char will_it_snow(double *t, double t_offset, double max_snow_temp,

--- a/vic/drivers/cesm/include/vic_mpi.h
+++ b/vic/drivers/cesm/include/vic_mpi.h
@@ -53,11 +53,10 @@ void get_scatter_nc_field_float(char *nc_name, char *var_name, size_t *start,
                                 size_t *count, float *var);
 void get_scatter_nc_field_int(char *nc_name, char *var_name, size_t *start,
                               size_t *count, int *var);
-void initialize_mpi(void);
+void initialize_mpi(MPI_Fint *MPI_COMM_VIC_F);
 void map(size_t size, size_t n, size_t *from_map, size_t *to_map, void *from,
          void *to);
-void mpi_map_decomp_domain(size_t ncells, size_t mpi_size,
-                           int **mpi_map_local_array_sizes,
+void mpi_map_decomp_domain(size_t ncells, int **mpi_map_local_array_sizes,
                            int **mpi_map_global_array_offsets,
                            size_t **mpi_map_mapping_array);
 

--- a/vic/drivers/cesm/src/cesm_def_mod_f.F90
+++ b/vic/drivers/cesm/src/cesm_def_mod_f.F90
@@ -36,15 +36,30 @@ MODULE vic_cesm_def_mod
   !!          vic_cesm_def.h
   !--------------------------------------------------------------------------
   TYPE, bind(C) :: vic_clock
-    INTEGER(C_INT)                                         :: timestep            !< timestep in seconds
-    INTEGER(C_INT16_T)                                     :: current_year        !< current year
-    INTEGER(C_INT16_T)                                     :: current_month       !< current month
-    INTEGER(C_INT16_T)                                     :: current_day         !< current day
-    INTEGER(C_INT)                                         :: current_dayseconds  !< current dayseconds
-    LOGICAL(C_BOOL)                                        :: state_flag          !< state flag
-    LOGICAL(C_BOOL)                                        :: stop_flag           !< stop flag
-    CHARACTER(len=VICMAXSTRING, kind=C_CHAR), DIMENSION(1) :: calendar            !< calendar
+    INTEGER(C_INT)         :: timestep                !< timestep in seconds
+    INTEGER(C_SHORT)       :: current_year            !< current year
+    INTEGER(C_SHORT)       :: current_month           !< current month
+    INTEGER(C_SHORT)       :: current_day             !< current day
+    INTEGER(C_INT)         :: current_dayseconds      !< current dayseconds
+    LOGICAL(C_BOOL)        :: state_flag              !< state flag
+    LOGICAL(C_BOOL)        :: stop_flag               !< stop flag
+    CHARACTER(KIND=C_CHAR) :: calendar(VICMAXSTRING)  !< calendar
   END TYPE vic_clock
+
+
+  !--------------------------------------------------------------------------
+  !> @brief   This structure stores meta data for the current case..
+  !! @note    Order is important and any changes here must be echoed in
+  !!          vic_cesm_def.h
+  !--------------------------------------------------------------------------
+  TYPE, bind(C) :: case_metadata
+    CHARACTER(KIND=C_CHAR) :: caseid(VICMAXSTRING)         !< case name
+    CHARACTER(KIND=C_CHAR) :: casedesc(VICMAXSTRING)       !< case description
+    CHARACTER(KIND=C_CHAR) :: starttype(VICMAXSTRING)      !< starttype
+    CHARACTER(KIND=C_CHAR) :: model_version(VICMAXSTRING)  !< cesm version
+    CHARACTER(KIND=C_CHAR) :: hostname(VICMAXSTRING)       !< hostname
+    CHARACTER(KIND=C_CHAR) :: username(VICMAXSTRING)       !< username
+  END TYPE case_metadata
 
   !--------------------------------------------------------------------------
   !> @brief   This type stores location information for individual grid cells.

--- a/vic/drivers/cesm/src/cesm_interface_f.F90
+++ b/vic/drivers/cesm/src/cesm_interface_f.F90
@@ -33,36 +33,43 @@ MODULE vic_cesm_interface
   !--------------------------------------------------------------------------
   ! Public interfaces
   !--------------------------------------------------------------------------
-  PUBLIC :: vic_cesm_init_mpi
+  PUBLIC :: initialize_log
+  PUBLIC :: initialize_mpi 
   PUBLIC :: vic_cesm_init
   PUBLIC :: vic_cesm_run
   PUBLIC :: vic_cesm_final
 
   !--------------------------------------------------------------------------
+  !> @brief   Initialize logging to stderr until after mpi is initialized
+  !--------------------------------------------------------------------------
+  INTERFACE
+     SUBROUTINE initialize_log() BIND(C, name='initialize_log')
+       USE, INTRINSIC :: ISO_C_BINDING
+       IMPLICIT NONE
+     END SUBROUTINE initialize_log
+  END INTERFACE
+
+  !--------------------------------------------------------------------------
   !> @brief   Init MPI Interface
   !--------------------------------------------------------------------------
   INTERFACE
-     INTEGER(C_INT) FUNCTION vic_cesm_init_mpi(MPI_COMM_VIC_F) BIND(C, name='vic_cesm_init_mpi')
+     SUBROUTINE initialize_mpi(MPI_COMM_VIC_F) BIND(C, name='initialize_mpi')
        USE, INTRINSIC :: ISO_C_BINDING
-       USE vic_cesm_def_mod
        IMPLICIT NONE
-       INTEGER(C_INT), INTENT(inout) :: MPI_COMM_VIC_F
-     END FUNCTION vic_cesm_init_mpi
+       INTEGER, INTENT(inout) :: MPI_COMM_VIC_F
+     END SUBROUTINE initialize_mpi
   END INTERFACE
 
   !--------------------------------------------------------------------------
   !> @brief   Init Interface
   !--------------------------------------------------------------------------
   INTERFACE
-     INTEGER(C_INT) FUNCTION vic_cesm_init(vic_global_param_file, caseid, &
-                                           runtype, vclock) BIND(C, name='vic_cesm_init')
+     INTEGER(C_INT) FUNCTION vic_cesm_init(vclock, cmeta) BIND(C, name='vic_cesm_init')
        USE, INTRINSIC :: ISO_C_BINDING
        USE vic_cesm_def_mod
        IMPLICIT NONE
-       CHARACTER(len=1, kind=C_CHAR), DIMENSION(*), INTENT(in) :: vic_global_param_file
-       CHARACTER(len=1, kind=C_CHAR), DIMENSION(*), INTENT(in) :: caseid
-       CHARACTER(len=1, kind=C_CHAR), DIMENSION(*), INTENT(in) :: runtype
        TYPE(vic_clock), INTENT(in) :: vclock
+       TYPE(case_metadata), INTENT(in) :: cmeta
      END FUNCTION vic_cesm_init
   END INTERFACE
 
@@ -74,7 +81,7 @@ MODULE vic_cesm_interface
        USE, INTRINSIC :: ISO_C_BINDING
        USE vic_cesm_def_mod
        IMPLICIT NONE
-       TYPE(vic_clock), INTENT(inout) :: vclock
+       TYPE(vic_clock), INTENT(in) :: vclock
      END FUNCTION vic_cesm_run
   END INTERFACE
 

--- a/vic/drivers/cesm/src/cesm_print_library_f.F90
+++ b/vic/drivers/cesm/src/cesm_print_library_f.F90
@@ -71,7 +71,7 @@ CONTAINS
     WRITE(iulog, *) '    current_dayseconds : ', vclock%current_dayseconds
     WRITE(iulog, *) '    state_flag         : ', vclock%state_flag
     WRITE(iulog, *) '    stop_flag          : ', vclock%stop_flag
-    WRITE(iulog, *) '    calendar           : ', trim(vclock%calendar)
+    WRITE(iulog, *) '    calendar           : ', TRIM(Copy_a2s(vclock%calendar))
 
   END SUBROUTINE print_vic_clock
 
@@ -205,5 +205,17 @@ CONTAINS
     WRITE(iulog, *) '    l2x_Flrl_rofice    : ', l2x_data%l2x_Flrl_rofice
 
   END SUBROUTINE print_l2x_data
+
+  !--------------------------------------------------------------------------
+  !> @brief   copy char array to string
+  !--------------------------------------------------------------------------
+  PURE FUNCTION Copy_a2s(a)  RESULT (s)    ! copy char array to string
+    CHARACTER,INTENT(IN) :: a(:)
+    CHARACTER(SIZE(a)) :: s
+    INTEGER :: i
+    DO i = 1,SIZE(a)
+      s(i:i) = a(i)
+    END DO
+  END FUNCTION Copy_a2s
 
 END MODULE vic_cesm_print_library

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -150,7 +150,9 @@ vic_cesm_put_data()
 
                 // albedo: direct , visible
                 // CESM units: unitless
-                albedo = AreaFactor * (atmos->shortwave[NR] / (atmos->shortwave[NR] - energy.NetShortAtmos));
+                albedo = AreaFactor *
+                         (atmos->shortwave[NR] /
+                          (atmos->shortwave[NR] - energy.NetShortAtmos));
                 l2x_vic[i].l2x_Sl_avsdr += albedo;
 
                 // albedo: direct , near-ir
@@ -230,7 +232,8 @@ vic_cesm_put_data()
 
                 // sensible heat flux
                 // CESM units: W m-2
-                l2x_vic[i].l2x_Fall_sen += -1 * AreaFactor * energy.AtmosSensible;
+                l2x_vic[i].l2x_Fall_sen += -1 * AreaFactor *
+                                           energy.AtmosSensible;
 
                 // upward longwave heat flux
                 // CESM units: W m-2
@@ -249,7 +252,8 @@ vic_cesm_put_data()
                     evap += snow.canopy_vapor_flux * MM_PER_M;
                     evap += veg_var.canopyevap;
                 }
-                l2x_vic[i].l2x_Fall_evap += -1 * AreaFactor * evap / global_param.dt;
+                l2x_vic[i].l2x_Fall_evap += -1 * AreaFactor * evap /
+                                            global_param.dt;
 
                 // heat flux shortwave net
                 l2x_vic[i].l2x_Fall_swnet += AreaFactor *

--- a/vic/drivers/cesm/src/get_global_domain.c
+++ b/vic/drivers/cesm/src/get_global_domain.c
@@ -62,7 +62,7 @@ get_global_domain(char          *nc_name,
         log_err("Memory allocation error in get_global_domain().");
     }
 
-    get_nc_field_int(nc_name, "run_cell", d2start, d2count, run);
+    get_nc_field_int(nc_name, "mask", d2start, d2count, run);
 
     for (y = 0, i = 0; y < global_domain->n_ny; y++) {
         for (x = 0; x < global_domain->n_nx; x++, i++) {
@@ -136,7 +136,7 @@ get_global_domain(char          *nc_name,
     get_nc_field_double(nc_name, "area",
                         d2start, d2count, var);
     for (i = 0; i < global_domain->ncells; i++) {
-        global_domain->locations[i].area = (double) var[idx[i]];
+        global_domain->locations[i].area = (double) var[idx[i]] * CONST_REARTH * CONST_REARTH;
     }
 
     // get fraction

--- a/vic/drivers/cesm/src/get_nc_dimension.c
+++ b/vic/drivers/cesm/src/get_nc_dimension.c
@@ -43,25 +43,26 @@ get_nc_dimension(char *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     // get dimension id
     status = nc_inq_dimid(nc_id, dim_name, &dim_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting dimension id %s in %s", dim_name, nc_name);
     }
 
     // get dimension size
     status = nc_inq_dimlen(nc_id, dim_id, &dim_size);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting dimension size for dim %s in %s", dim_name,
+                nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return dim_size;

--- a/vic/drivers/cesm/src/get_nc_field.c
+++ b/vic/drivers/cesm/src/get_nc_field.c
@@ -45,24 +45,24 @@ get_nc_field_double(char   *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     /* get NetCDF variable */
     status = nc_inq_varid(nc_id, var_name, &var_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_get_vara_double(nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting values for %s in %s", var_name, nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return status;
@@ -85,24 +85,24 @@ get_nc_field_float(char   *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     /* get NetCDF variable */
     status = nc_inq_varid(nc_id, var_name, &var_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_get_vara_float(nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting values for %s in %s", var_name, nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return status;
@@ -125,24 +125,24 @@ get_nc_field_int(char   *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     /* get NetCDF variable */
     status = nc_inq_varid(nc_id, var_name, &var_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_get_vara_int(nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting values for %s in %s", var_name, nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return status;

--- a/vic/drivers/cesm/src/init_library.c
+++ b/vic/drivers/cesm/src/init_library.c
@@ -245,6 +245,6 @@ initialize_l2x_data()
         l2x_vic[i].l2x_Fall_flxvoc = SHR_CONST_SPVAL;
         l2x_vic[i].l2x_Flrl_rofliq = SHR_CONST_SPVAL;
         l2x_vic[i].l2x_Flrl_rofice = SHR_CONST_SPVAL;
-        l2x_vic[i].l2x_vars_set = false;
+        l2x_vic[i].l2x_vars_set = true;
     }
 }

--- a/vic/drivers/cesm/src/print_library_cesm.c
+++ b/vic/drivers/cesm/src/print_library_cesm.c
@@ -212,7 +212,22 @@ print_vic_clock(vic_clock *vclock)
             vclock->current_dayseconds);
     fprintf(LOG_DEST, "\tstate_flag         : %d\n", vclock->state_flag);
     fprintf(LOG_DEST, "\tstop_flag          : %d\n", vclock->stop_flag);
-    fprintf(LOG_DEST, "\tcalendar           : %s\n", vclock->calendar);
+    fprintf(LOG_DEST, "\tcalendar           : %s\n", trim(vclock->calendar));
+}
+
+/******************************************************************************
+ * @brief    Print case_metadata structure.
+ *****************************************************************************/
+void
+print_case_metadata(case_metadata *cmeta)
+{
+    fprintf(LOG_DEST, "case_metadata   :\n");
+    fprintf(LOG_DEST, "\tcaseid        : %s\n", trim(cmeta->caseid));
+    fprintf(LOG_DEST, "\tcasedesc      : %s\n", trim(cmeta->casedesc));
+    fprintf(LOG_DEST, "\tstarttype     : %s\n", trim(cmeta->starttype));
+    fprintf(LOG_DEST, "\tmodel_version : %s\n", trim(cmeta->model_version));
+    fprintf(LOG_DEST, "\thostname      : %s\n", trim(cmeta->hostname));
+    fprintf(LOG_DEST, "\tusername      : %s\n", trim(cmeta->username));
 }
 
 /******************************************************************************

--- a/vic/drivers/cesm/src/put_nc_field.c
+++ b/vic/drivers/cesm/src/put_nc_field.c
@@ -53,14 +53,14 @@ put_nc_field_double(char   *nc_name,
                          NC_WRITE | NC_NOCLOBBER | NC_NETCDF4 | NC_CLASSIC_MODEL,
                          nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error opening %s", nc_name);
         }
         *open = true;
 
         // set the NC_FILL attribute
         status = nc_set_fill(*nc_id, NC_FILL, &old_fill_mode);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error setting fill value in %s", nc_name);
         }
     }
 
@@ -70,33 +70,34 @@ put_nc_field_double(char   *nc_name,
         // enter define mode
         status = nc_redef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error entering define mode in %s", nc_name);
         }
         // define the variable
         status = nc_def_var(*nc_id, var_name, NC_DOUBLE, ndims, dimids,
                             &var_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error defining variable %s in %s", var_name, nc_name);
         }
         // set the fill value attribute
         status = nc_put_att_double(*nc_id, var_id, "_FillValue", NC_DOUBLE, 1,
                                    &fillval);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error putting _FillValue attribute to %s in %s", var_name,
+                    nc_name)
         }
         // leave define mode
         status = nc_enddef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error ending define mode for %s in %s", var_name, nc_name);
         }
     }
     else if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_put_vara_double(*nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error writing values to %s in %s", var_name, nc_name);
     }
 
     // keep the file open
@@ -129,14 +130,14 @@ put_nc_field_int(char   *nc_name,
                          NC_WRITE | NC_NOCLOBBER | NC_NETCDF4 | NC_CLASSIC_MODEL,
                          nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error opening %s", nc_name);
         }
         *open = true;
 
         // set the NC_FILL attribute
         status = nc_set_fill(*nc_id, NC_FILL, &old_fill_mode);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error setting fill value in %s", nc_name);
         }
     }
 
@@ -146,33 +147,34 @@ put_nc_field_int(char   *nc_name,
         // enter define mode
         status = nc_redef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error entering define mode in %s", nc_name);
         }
         // define the variable
         status = nc_def_var(*nc_id, var_name, NC_INT, ndims, dimids,
                             &var_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error defining variable %s in %s", var_name, nc_name);
         }
         // set the fill value attribute
         status = nc_put_att_int(*nc_id, var_id, "_FillValue", NC_INT, 1,
                                 &fillval);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error putting _FillValue attribute to %s in %s", var_name,
+                    nc_name);
         }
         // leave define mode
         status = nc_enddef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error ending define mode for %s in %s", var_name, nc_name);
         }
     }
     else if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_put_vara_int(*nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error writing values to %s in %s", var_name, nc_name);
     }
 
     // keep the file open

--- a/vic/drivers/cesm/src/vic_cesm_time.c
+++ b/vic/drivers/cesm/src/vic_cesm_time.c
@@ -36,10 +36,13 @@ double numdate = MISSING;
 void
 initialize_cesm_time(void)
 {
+    extern size_t              current;
     extern dmy_struct          dmy;
     extern global_param_struct global_param;
 
     debug("In initialize_cesm_time");
+
+    current = 0;
 
     // initialize time
     initialize_time();
@@ -65,8 +68,11 @@ initialize_cesm_time(void)
 void
 advance_time(void)
 {
+    extern size_t              current;
     extern dmy_struct          dmy;
     extern global_param_struct global_param;
+
+    current++;
 
     numdate += dt_time_units;
 

--- a/vic/drivers/cesm/src/vic_finalize.c
+++ b/vic/drivers/cesm/src/vic_finalize.c
@@ -66,7 +66,7 @@ vic_finalize(void)
         if (nc_hist_file.open == true) {
             status = nc_close(nc_hist_file.nc_id);
             if (status != NC_NOERR) {
-                log_ncerr(status);
+                log_err("Error closing history file %s", nc_hist_file.fname);
             }
         }
     }

--- a/vic/drivers/cesm/src/vic_force.c
+++ b/vic/drivers/cesm/src/vic_force.c
@@ -59,7 +59,12 @@ vic_force(void)
     // Check to make sure variables have been set by coupler
     for (i = 0; i < local_domain.ncells; i++) {
         if (!x2l_vic[i].x2l_vars_set) {
-            log_err("x2l_vars_set is false");
+            if (current == 0) {
+               make_dummy_forcings(&x2l_vic[i]);
+            }
+            else {
+                log_err("x2l_vars_set is false");
+            }
         }
     }
 
@@ -104,10 +109,15 @@ vic_force(void)
         for (i = 0; i < local_domain.ncells; i++) {
             // CESM units: n/a (calculated from SW fluxes)
             // VIC units: fraction
-            atmos[i].fdir[j] = (x2l_vic[i].x2l_Faxa_swndr +
-                                x2l_vic[i].x2l_Faxa_swvdr) /
-                               (x2l_vic[i].x2l_Faxa_swndf +
-                                x2l_vic[i].x2l_Faxa_swvdf);
+            if (atmos[i].shortwave[j] != 0.) {
+                atmos[i].fdir[j] = (x2l_vic[i].x2l_Faxa_swndr +
+                                    x2l_vic[i].x2l_Faxa_swvdr) /
+                                   (x2l_vic[i].x2l_Faxa_swndf +
+                                    x2l_vic[i].x2l_Faxa_swvdf);
+           }
+           else {
+               atmos[i].fdir[j] = 0.;
+           }
         }
     }
 
@@ -336,4 +346,49 @@ will_it_snow(double *t,
     }
 
     return 0;
+}
+
+/******************************************************************************
+ * @brief   dummy forcings for initialization (should be removed or never used)
+ *****************************************************************************/
+void
+make_dummy_forcings(x2l_data_struct *x2l)
+{
+    extern x2l_data_struct    *x2l_vic;
+    extern domain_struct       local_domain;
+
+    x2l->x2l_Sa_z = 10;  /** bottom atm level height */
+    x2l->x2l_Sa_u = 1.;  /** bottom atm level zon wind */
+    x2l->x2l_Sa_v = 1.;  /** bottom atm level mer wind */
+    x2l->x2l_Sa_ptem = 1.;  /** bottom atm level pot temp */
+    x2l->x2l_Sa_shum = 0.02;  /** bottom atm level spec hum */
+    x2l->x2l_Sa_pbot = 101325.;  /** bottom atm level pressure */
+    x2l->x2l_Sa_tbot = 1.;  /** bottom atm level temp */
+    x2l->x2l_Faxa_lwdn = 50;  /** downward lw heat flux */
+    x2l->x2l_Faxa_rainc = 0.;  /** prec: liquid "convective" */
+    x2l->x2l_Faxa_rainl = 0.;  /** prec: liquid "large scale" */
+    x2l->x2l_Faxa_snowc = 0.;  /** prec: frozen "convective" */
+    x2l->x2l_Faxa_snowl = 0.;  /** prec: frozen "large scale" */
+    x2l->x2l_Faxa_swndr = 1.;  /** sw: nir direct  downward */
+    x2l->x2l_Faxa_swvdr = 1.;  /** sw: vis direct  downward */
+    x2l->x2l_Faxa_swndf = 1.;  /** sw: nir diffuse downward */
+    x2l->x2l_Faxa_swvdf = 1.;  /** sw: vis diffuse downward */
+    x2l->x2l_Sa_co2prog = 0.;  /** bottom atm level prognostic co2 */
+    x2l->x2l_Sa_co2diag = 0.;  /** bottom atm level diagnostic co2 */
+    x2l->x2l_Faxa_bcphidry = 0.;  /** flux: Black Carbon hydrophilic dry deposition */
+    x2l->x2l_Faxa_bcphodry = 0.;  /** flux: Black Carbon hydrophobic dry deposition */
+    x2l->x2l_Faxa_bcphiwet = 0.;  /** flux: Black Carbon hydrophilic wet deposition */
+    x2l->x2l_Faxa_ocphidry = 0.;  /** flux: Organic Carbon hydrophilic dry deposition */
+    x2l->x2l_Faxa_ocphodry = 0.;  /** flux: Organic Carbon hydrophobic dry deposition */
+    x2l->x2l_Faxa_ocphiwet = 0.;  /** flux: Organic Carbon hydrophilic dry deposition */
+    x2l->x2l_Faxa_dstwet1 = 0.;  /** flux: Size 1 dust -- wet deposition */
+    x2l->x2l_Faxa_dstwet2 = 0.;  /** flux: Size 2 dust -- wet deposition */
+    x2l->x2l_Faxa_dstwet3 = 0.;  /** flux: Size 3 dust -- wet deposition */
+    x2l->x2l_Faxa_dstwet4 = 0.;  /** flux: Size 4 dust -- wet deposition */
+    x2l->x2l_Faxa_dstdry1 = 0.;  /** flux: Size 1 dust -- dry deposition */
+    x2l->x2l_Faxa_dstdry2 = 0.;  /** flux: Size 2 dust -- dry deposition */
+    x2l->x2l_Faxa_dstdry3 = 0.;  /** flux: Size 3 dust -- dry deposition */
+    x2l->x2l_Faxa_dstdry4 = 0.;  /** flux: Size 4 dust -- dry deposition */
+    x2l->x2l_Flrr_flood = 0.;  /** rtm->lnd rof (flood) flux */
+    x2l->x2l_vars_set = true; /** x2l set flag */
 }

--- a/vic/drivers/cesm/src/vic_init.c
+++ b/vic/drivers/cesm/src/vic_init.c
@@ -1050,17 +1050,19 @@ vic_init(void)
         // rescale vegetation classes to 1.0 if their sum is greater than 0.99
         // otherwise throw an error
         // TBD: Need better check for equal to 1.
-        if (veg_con[i][0].Cv_sum != 1.) {
+        if (veg_con[i][0].Cv_sum > 1.) {
             sprint_location(locstr, &(local_domain.locations[i]));
             log_warn("Cv !=  1.0 (%f) at grid cell %zd. Rescaling ...\n%s",
                      veg_con[i][0].Cv_sum, i, locstr);
             for (j = 0; j < options.NVEGTYPES; j++) {
                 vidx = veg_con_map[i].vidx[j];
                 if (vidx != -1) {
-                    veg_con[i][vidx].Cv /= veg_con[i][0].Cv_sum;
+                    ;
+                    // veg_con[i][vidx].Cv /= veg_con[i][0].Cv_sum;
                 }
             }
-            veg_con[i][0].Cv_sum = 1.;
+            // veg_con[i][0].Cv_sum = 1.;
+            log_warn("Cv_sum does not include bare soil fraction and vic_init wanted to rescale Cv for all veg types");
         }
     }
 

--- a/vic/drivers/cesm/src/vic_init_output.c
+++ b/vic/drivers/cesm/src/vic_init_output.c
@@ -54,8 +54,6 @@ vic_init_output(void)
     int                        status;
     size_t                     i;
 
-    debug("In vic_init_output");
-
     // initialize the output data structures
     for (i = 0; i < local_domain.ncells; i++) {
         put_data(&(all_vars[i]), &(atmos[i]), &(soil_con[i]), veg_con[i],
@@ -127,78 +125,78 @@ initialize_history_file(nc_file_struct *nc)
     // open the netcdf file
     status = nc_create(nc->fname, NC_NETCDF4 | NC_CLASSIC_MODEL, &(nc->nc_id));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error creating %s", nc->fname);
     }
     nc->open = true;
 
     // set the NC_FILL attribute
     status = nc_set_fill(nc->nc_id, NC_FILL, &old_fill_mode);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error setting fill value in %s", nc->fname);
     }
 
     // define netcdf dimensions
     status = nc_def_dim(nc->nc_id, "snow_band", nc->band_size,
                         &(nc->band_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining snow_band dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "front", nc->front_size,
                         &(nc->front_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining front dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "frost_area", nc->frost_size,
                         &(nc->frost_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining frost_area dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nlayer", nc->layer_size,
                         &(nc->layer_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nlayer dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "ni", nc->ni_size, &(nc->ni_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining ni dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nj", nc->nj_size, &(nc->nj_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nj dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "node", nc->node_size, &(nc->node_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining node dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "root_zone", nc->root_zone_size,
                         &(nc->root_zone_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining root_zone dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "veg_class", nc->veg_size,
                         &(nc->veg_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining veg_class dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "time", nc->time_size,
                         &(nc->time_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining time dimenension in %s", nc->fname);
     }
 
 
     // leave define mode
     status = nc_enddef(nc->nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error leaving define mode for %s", nc->fname);
     }
 }

--- a/vic/drivers/cesm/src/vic_store.c
+++ b/vic/drivers/cesm/src/vic_store.c
@@ -919,7 +919,7 @@ vic_store(void)
     if (nc_state_file.open == true) {
         status = nc_close(nc_state_file.nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error closing %s", nc_state_file.fname)
         }
     }
 
@@ -965,66 +965,66 @@ initialize_state_file(nc_file_struct *nc)
     // open the netcdf file
     status = nc_create(nc->fname, NC_NETCDF4 | NC_CLASSIC_MODEL, &(nc->nc_id));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error creating %s", nc->fname);
     }
     nc->open = true;
 
     // set the NC_FILL attribute
     status = nc_set_fill(nc->nc_id, NC_FILL, &old_fill_mode);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error setting fill value in %s", nc->fname);
     }
 
     // define netcdf dimensions
     status = nc_def_dim(nc->nc_id, "snow_band", nc->band_size,
                         &(nc->band_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining snow_band in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "frost_area", nc->frost_size,
                         &(nc->frost_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining frost_area in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nlayer", nc->layer_size,
                         &(nc->layer_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nlayer in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "ni", nc->ni_size, &(nc->ni_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining ni in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nj", nc->nj_size, &(nc->nj_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nj in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "node", nc->node_size, &(nc->node_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining node in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "root_zone", nc->root_zone_size,
                         &(nc->root_zone_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining root_zone in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "veg_class", nc->veg_size,
                         &(nc->veg_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining veg_class in %s", nc->fname);
     }
 
     // leave define mode
     status = nc_enddef(nc->nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error leaving define mode for %s", nc->fname);
     }
 }
 

--- a/vic/drivers/image/include/vic_mpi.h
+++ b/vic/drivers/image/include/vic_mpi.h
@@ -31,6 +31,7 @@
 #include <mpi.h>
 #include <stdbool.h>
 
+void create_MPI_filenames_struct_type(MPI_Datatype *mpi_type);
 void create_MPI_global_struct_type(MPI_Datatype *mpi_type);
 void create_MPI_location_struct_type(MPI_Datatype *mpi_type);
 void create_MPI_nc_file_struct_type(MPI_Datatype *mpi_type);

--- a/vic/drivers/image/src/get_nc_dimension.c
+++ b/vic/drivers/image/src/get_nc_dimension.c
@@ -43,25 +43,26 @@ get_nc_dimension(char *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     // get dimension id
     status = nc_inq_dimid(nc_id, dim_name, &dim_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting dimension id %s in %s", dim_name, nc_name);
     }
 
     // get dimension size
     status = nc_inq_dimlen(nc_id, dim_id, &dim_size);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting dimension size for dim %s in %s", dim_name,
+                nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return dim_size;

--- a/vic/drivers/image/src/get_nc_field.c
+++ b/vic/drivers/image/src/get_nc_field.c
@@ -45,24 +45,24 @@ get_nc_field_double(char   *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     /* get NetCDF variable */
     status = nc_inq_varid(nc_id, var_name, &var_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_get_vara_double(nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting values for %s in %s", var_name, nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return status;
@@ -85,24 +85,24 @@ get_nc_field_float(char   *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     /* get NetCDF variable */
     status = nc_inq_varid(nc_id, var_name, &var_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_get_vara_float(nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting values for %s in %s", var_name, nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return status;
@@ -125,24 +125,24 @@ get_nc_field_int(char   *nc_name,
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error opening %s", nc_name);
     }
 
     /* get NetCDF variable */
     status = nc_inq_varid(nc_id, var_name, &var_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_get_vara_int(nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting values for %s in %s", var_name, nc_name);
     }
 
     // close the netcdf file
     status = nc_close(nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error closing %s", nc_name);
     }
 
     return status;

--- a/vic/drivers/image/src/put_nc_field.c
+++ b/vic/drivers/image/src/put_nc_field.c
@@ -53,14 +53,14 @@ put_nc_field_double(char   *nc_name,
                          NC_WRITE | NC_NOCLOBBER | NC_NETCDF4 | NC_CLASSIC_MODEL,
                          nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error opening %s", nc_name);
         }
         *open = true;
 
         // set the NC_FILL attribute
         status = nc_set_fill(*nc_id, NC_FILL, &old_fill_mode);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error setting fill value in %s", nc_name);
         }
     }
 
@@ -70,33 +70,34 @@ put_nc_field_double(char   *nc_name,
         // enter define mode
         status = nc_redef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error entering define mode in %s", nc_name);
         }
         // define the variable
         status = nc_def_var(*nc_id, var_name, NC_DOUBLE, ndims, dimids,
                             &var_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error defining variable %s in %s", var_name, nc_name);
         }
         // set the fill value attribute
         status = nc_put_att_double(*nc_id, var_id, "_FillValue", NC_DOUBLE, 1,
                                    &fillval);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error putting _FillValue attribute to %s in %s", var_name,
+                    nc_name)
         }
         // leave define mode
         status = nc_enddef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error ending define mode for %s in %s", var_name, nc_name);
         }
     }
     else if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_put_vara_double(*nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error writing values to %s in %s", var_name, nc_name);
     }
 
     // keep the file open
@@ -129,14 +130,14 @@ put_nc_field_int(char   *nc_name,
                          NC_WRITE | NC_NOCLOBBER | NC_NETCDF4 | NC_CLASSIC_MODEL,
                          nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error opening %s", nc_name);
         }
         *open = true;
 
         // set the NC_FILL attribute
         status = nc_set_fill(*nc_id, NC_FILL, &old_fill_mode);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error setting fill value in %s", nc_name);
         }
     }
 
@@ -146,33 +147,34 @@ put_nc_field_int(char   *nc_name,
         // enter define mode
         status = nc_redef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error entering define mode in %s", nc_name);
         }
         // define the variable
         status = nc_def_var(*nc_id, var_name, NC_INT, ndims, dimids,
                             &var_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error defining variable %s in %s", var_name, nc_name);
         }
         // set the fill value attribute
         status = nc_put_att_int(*nc_id, var_id, "_FillValue", NC_INT, 1,
                                 &fillval);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error putting _FillValue attribute to %s in %s", var_name,
+                    nc_name);
         }
         // leave define mode
         status = nc_enddef(*nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error ending define mode for %s in %s", var_name, nc_name);
         }
     }
     else if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error getting variable id for %s in %s", var_name, nc_name);
     }
 
     status = nc_put_vara_int(*nc_id, var_id, start, count, var);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error writing values to %s in %s", var_name, nc_name);
     }
 
     // keep the file open

--- a/vic/drivers/image/src/vic_finalize.c
+++ b/vic/drivers/image/src/vic_finalize.c
@@ -67,7 +67,7 @@ vic_finalize(void)
         if (nc_hist_file.open == true) {
             status = nc_close(nc_hist_file.nc_id);
             if (status != NC_NOERR) {
-                log_ncerr(status);
+                log_err("Error history file");
             }
         }
     }

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -42,6 +42,7 @@ domain_struct       local_domain;
 global_param_struct global_param;
 lake_con_struct     lake_con;
 MPI_Datatype        mpi_global_struct_type;
+MPI_Datatype        mpi_filenames_struct_type;
 MPI_Datatype        mpi_location_struct_type;
 MPI_Datatype        mpi_nc_file_struct_type;
 MPI_Datatype        mpi_option_struct_type;

--- a/vic/drivers/image/src/vic_init_output.c
+++ b/vic/drivers/image/src/vic_init_output.c
@@ -125,78 +125,78 @@ initialize_history_file(nc_file_struct *nc)
     // open the netcdf file
     status = nc_create(nc->fname, NC_NETCDF4 | NC_CLASSIC_MODEL, &(nc->nc_id));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error creating %s", nc->fname);
     }
     nc->open = true;
 
     // set the NC_FILL attribute
     status = nc_set_fill(nc->nc_id, NC_FILL, &old_fill_mode);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error setting fill value in %s", nc->fname);
     }
 
     // define netcdf dimensions
     status = nc_def_dim(nc->nc_id, "snow_band", nc->band_size,
                         &(nc->band_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining snow_band dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "front", nc->front_size,
                         &(nc->front_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining front dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "frost_area", nc->frost_size,
                         &(nc->frost_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining frost_area dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nlayer", nc->layer_size,
                         &(nc->layer_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nlayer dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "ni", nc->ni_size, &(nc->ni_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining ni dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nj", nc->nj_size, &(nc->nj_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nj dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "node", nc->node_size, &(nc->node_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining node dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "root_zone", nc->root_zone_size,
                         &(nc->root_zone_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining root_zone dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "veg_class", nc->veg_size,
                         &(nc->veg_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining veg_class dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "time", nc->time_size,
                         &(nc->time_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining time dimenension in %s", nc->fname);
     }
 
 
     // leave define mode
     status = nc_enddef(nc->nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error leaving define mode for %s", nc->fname);
     }
 }

--- a/vic/drivers/image/src/vic_mpi_support.c
+++ b/vic/drivers/image/src/vic_mpi_support.c
@@ -34,6 +34,7 @@ void
 initialize_mpi(void)
 {
     extern MPI_Datatype mpi_global_struct_type;
+    extern MPI_Datatype mpi_filenames_struct_type;
     extern MPI_Datatype mpi_location_struct_type;
     extern MPI_Datatype mpi_nc_file_struct_type;
     extern MPI_Datatype mpi_option_struct_type;
@@ -55,6 +56,7 @@ initialize_mpi(void)
 
     // initialize MPI data structures
     create_MPI_global_struct_type(&mpi_global_struct_type);
+    create_MPI_filenames_struct_type(&mpi_filenames_struct_type);
     create_MPI_location_struct_type(&mpi_location_struct_type);
     create_MPI_nc_file_struct_type(&mpi_nc_file_struct_type);
     create_MPI_option_struct_type(&mpi_option_struct_type);
@@ -80,7 +82,7 @@ create_MPI_global_struct_type(MPI_Datatype *mpi_type)
     MPI_Datatype *mpi_types;
 
     // nitems has to equal the number of elements in global_param_struct
-    nitems = 35;
+    nitems = 34;
     blocklengths = (int *) malloc(nitems * sizeof(int));
     if (blocklengths == NULL) {
         log_err("Memory allocation error in create_MPI_global_struct_type().")
@@ -247,11 +249,6 @@ create_MPI_global_struct_type(MPI_Datatype *mpi_type)
     offsets[i] = offsetof(global_param_struct, time_origin_num);
     mpi_types[i++] = MPI_DOUBLE;
 
-    // char caseid[MAXSTRING];
-    offsets[i] = offsetof(global_param_struct, time_origin_num);
-    blocklengths[i] = MAXSTRING;
-    mpi_types[i++] = MPI_CHAR;
-
     // make sure that the we have the right number of elements
     if (i != (size_t) nitems) {
         log_err("Miscount in create_MPI_global_struct_type(): "
@@ -267,6 +264,134 @@ create_MPI_global_struct_type(MPI_Datatype *mpi_type)
     status = MPI_Type_commit(mpi_type);
     if (status != MPI_SUCCESS) {
         log_err("MPI error in create_MPI_global_struct_type(): %d\n", status);
+    }
+
+    // cleanup
+    free(blocklengths);
+    free(offsets);
+    free(mpi_types);
+}
+
+/******************************************************************************
+ * @brief   Create an MPI_Datatype that represents the filenames_struct
+ * @details This allows MPI operations in which the entire filenames_struct
+ *          can be treated as an MPI_Datatype. NOTE: This function needs to be
+ *          kept in-sync with the global_param_struct data type in vic_def.h.
+ *
+ * @param mpi_type MPI_Datatype that can be used in MPI operations
+ *****************************************************************************/
+void
+create_MPI_filenames_struct_type(MPI_Datatype *mpi_type)
+{
+    int           nitems; // number of elements in struct
+    int           status;
+    int          *blocklengths;
+    size_t        i;
+    MPI_Aint     *offsets;
+    MPI_Datatype *mpi_types;
+
+    // nitems has to equal the number of elements in filenames_struct
+    nitems = 14;
+    blocklengths = (int *) malloc(nitems * sizeof(int));
+    if (blocklengths == NULL) {
+        log_err("Memory allocation error in create_MPI_filenames_struct_type().")
+    }
+
+    offsets = (MPI_Aint *) malloc(nitems * sizeof(MPI_Aint));
+    if (offsets == NULL) {
+        log_err("Memory allocation error in create_MPI_filenames_struct_type().")
+    }
+
+    mpi_types = (MPI_Datatype *) malloc(nitems * sizeof(MPI_Datatype));
+    if (mpi_types == NULL) {
+        log_err("Memory allocation error in create_MPI_filenames_struct_type().")
+    }
+
+    // most of the elements in filenames_struct are character arrays. Use
+    // MAXSTRING as the default block length and reset as needed
+    for (i = 0; i < (size_t) nitems; i++) {
+        blocklengths[i] = MAXSTRING;
+    }
+
+    // reset i
+    i = 0;
+
+    // char forcing[2][MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, forcing);
+    blocklengths[i] *= 2;
+    mpi_types[i++] = MPI_CHAR;
+
+    // char f_path_pfx[2][MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, f_path_pfx);
+    blocklengths[i] *= 2;
+    mpi_types[i++] = MPI_CHAR;
+
+    // char global[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, global);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char domain[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, domain);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char constants[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, constants);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char init_state[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, init_state);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char lakeparam[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, lakeparam);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char result_dir[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, result_dir);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char snowband[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, snowband);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char soil[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, soil);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char statefile[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, statefile);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char veg[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, veg);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char veglib[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, veglib);
+    mpi_types[i++] = MPI_CHAR;
+
+    // char log_path[MAXSTRING];
+    offsets[i] = offsetof(filenames_struct, log_path);
+    mpi_types[i++] = MPI_CHAR;
+
+
+    // make sure that the we have the right number of elements
+    if (i != (size_t) nitems) {
+        log_err("Miscount in create_MPI_filenames_struct_type(): "
+                "%zd not equal to %d\n", i, nitems);
+    }
+
+    status = MPI_Type_create_struct(nitems, blocklengths, offsets, mpi_types,
+                                    mpi_type);
+    if (status != MPI_SUCCESS) {
+        log_err("MPI error in create_MPI_filenames_struct_type(): %d\n",
+                status);
+    }
+
+    status = MPI_Type_commit(mpi_type);
+    if (status != MPI_SUCCESS) {
+        log_err("MPI error in create_MPI_filenames_struct_type(): %d\n",
+                status);
     }
 
     // cleanup

--- a/vic/drivers/image/src/vic_start.c
+++ b/vic/drivers/image/src/vic_start.c
@@ -46,6 +46,7 @@ vic_start(void)
     extern domain_struct       local_domain;
     extern global_param_struct global_param;
     extern MPI_Datatype        mpi_global_struct_type;
+    extern MPI_Datatype        mpi_filenames_struct_type;
     extern MPI_Datatype        mpi_location_struct_type;
     extern MPI_Datatype        mpi_option_struct_type;
     extern MPI_Datatype        mpi_param_struct_type;
@@ -66,6 +67,12 @@ vic_start(void)
         // read global settings
         filep.globalparam = open_file(filenames.global, "r");
         get_global_param(filep.globalparam);
+    }
+
+    status = MPI_Bcast(&filenames, 1, mpi_filenames_struct_type,
+                       0, MPI_COMM_WORLD);
+    if (status != MPI_SUCCESS) {
+        log_err("MPI error in vic_start(): %d\n", status);
     }
 
     // Set Log Destination

--- a/vic/drivers/image/src/vic_store.c
+++ b/vic/drivers/image/src/vic_store.c
@@ -919,7 +919,7 @@ vic_store(void)
     if (nc_state_file.open == true) {
         status = nc_close(nc_state_file.nc_id);
         if (status != NC_NOERR) {
-            log_ncerr(status);
+            log_err("Error closing %s", nc_state_file.fname);
         }
     }
 
@@ -962,65 +962,65 @@ initialize_state_file(nc_file_struct *nc)
     // open the netcdf file
     status = nc_create(nc->fname, NC_NETCDF4 | NC_CLASSIC_MODEL, &(nc->nc_id));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error creating %s", nc->fname);
     }
     nc->open = true;
 
     // set the NC_FILL attribute
     status = nc_set_fill(nc->nc_id, NC_FILL, &old_fill_mode);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error setting fill value in %s", nc->fname);
     }
 
     // define netcdf dimensions
     status = nc_def_dim(nc->nc_id, "snow_band", nc->band_size,
                         &(nc->band_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining snow_band in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "frost_area", nc->frost_size,
                         &(nc->frost_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining frost_area in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nlayer", nc->layer_size,
                         &(nc->layer_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nlayer in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "ni", nc->ni_size, &(nc->ni_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining ni in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "nj", nc->nj_size, &(nc->nj_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining nj in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "node", nc->node_size, &(nc->node_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining node in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "root_zone", nc->root_zone_size,
                         &(nc->root_zone_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining root_zone in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "veg_class", nc->veg_size,
                         &(nc->veg_dimid));
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error defining veg_class in %s", nc->fname);
     }
 
     // leave define mode
     status = nc_enddef(nc->nc_id);
     if (status != NC_NOERR) {
-        log_ncerr(status);
+        log_err("Error leaving define mode for %s", nc->fname);
     }
 }

--- a/vic/drivers/shared/src/initialize_global.c
+++ b/vic/drivers/shared/src/initialize_global.c
@@ -76,5 +76,4 @@ initialize_global()
     global_param.calendar = CALENDAR_STANDARD;
     global_param.time_units = TIME_UNITS_DAYS;
     global_param.time_origin_num = MISSING;
-    strcpy(global_param.caseid, "MISSING");
 }

--- a/vic/drivers/shared/src/initialize_parameters.c
+++ b/vic/drivers/shared/src/initialize_parameters.c
@@ -46,7 +46,7 @@ initialize_parameters()
     param.WIND_SPEED_MIN = 0.1;
 
     // Huge Resistance Term
-    param.HUGE_RESIST = DBL_MAX;
+    param.HUGE_RESIST = 1.e20;
 
     // Surface Albedo Parameters
     param.ALBEDO_BARE_SOIL = 0.2;

--- a/vic/drivers/shared/src/put_data.c
+++ b/vic/drivers/shared/src/put_data.c
@@ -515,11 +515,12 @@ put_data(all_vars_struct   *all_vars,
             out_data[OUT_SOIL_ICE].data[index];
         out_data[OUT_DELSOILMOIST].data[0] +=
             out_data[OUT_SOIL_MOIST].data[index];
-        out_data[OUT_SMLIQFRAC].data[index] =
+        log_warn("Duct tape begins here: %f %f", out_data[OUT_SOIL_LIQ].data[index], out_data[OUT_SOIL_MOIST].data[index]);
+        /*out_data[OUT_SMLIQFRAC].data[index] =
             out_data[OUT_SOIL_LIQ].data[index] /
             out_data[OUT_SOIL_MOIST].data[index];
         out_data[OUT_SMFROZFRAC].data[index] = \
-            1 - out_data[OUT_SMLIQFRAC].data[index];
+            1 - out_data[OUT_SMLIQFRAC].data[index]; TODO: figure out why soil_liq is zero in some cases */
     }
     if (rec >= 0) {
         out_data[OUT_DELSOILMOIST].data[0] -= save_data->total_soil_moist;

--- a/vic/drivers/shared/src/vic_log.c
+++ b/vic/drivers/shared/src/vic_log.c
@@ -53,22 +53,22 @@ finalize_logging(void)
 void
 get_current_datetime(char *cdt)
 {
-    char         ymd[8];
+    char         ymd[MAXSTRING];
     struct tm    timeinfo;
     unsigned int seconds_since_midnight;
     time_t       curr_date_time;
 
     curr_date_time = time(NULL);
     if (curr_date_time == -1) {
-        return;
+        log_err("Something went wrong getting the current time!");
     }
 
     localtime_r(&curr_date_time, &timeinfo);
 
     seconds_since_midnight = (unsigned int) curr_date_time % CONST_CDAY;
 
-    if (strftime(ymd, 7, "%Y%m%d", &timeinfo) == 0) {
-        return;
+    if (strftime(ymd, MAXSTRING - 1, "%Y%m%d", &timeinfo) == 0) {
+        log_err("Something went wrong converting the current time info to ymd");
     }
 
     sprintf(cdt, "%s-%05d", ymd, seconds_since_midnight);
@@ -141,4 +141,31 @@ setup_logging(int id)
     else {
         log_info("Logging to stderr");
     }
+}
+
+/******************************************************************************
+ * @brief    Print traceback for current error position
+ *****************************************************************************/
+void
+print_trace(void)
+{
+    void  *array[50];
+    size_t size;
+    char **strings;
+    size_t i;
+
+    size = backtrace(array, 50);
+    strings = backtrace_symbols(array, size);
+
+    /* Note: we are ignoring the first and last stack frame
+       the first is this function, the last is the linker, neither are
+       particularly useful */
+    fprintf(LOG_DEST,
+            "---------------------------------------------------------------------------\n");
+    fprintf(LOG_DEST, "Traceback (most recent call last):\n");
+    for (i = size - 2; i > 0; i--) {
+        fprintf(LOG_DEST, "%s\n", strings[i]);
+    }
+
+    free(strings);
 }

--- a/vic/drivers/shared/src/vic_time.c
+++ b/vic/drivers/shared/src/vic_time.c
@@ -790,7 +790,8 @@ calendar_from_char(char *cal_str)
     else if (strcasecmp("PROLEPTIC_GREGORIAN", cal_str) == 0) {
         return CALENDAR_PROLEPTIC_GREGORIAN;
     }
-    else if (strcasecmp("NOLEAP", cal_str) == 0) {
+    else if ((strcasecmp("NOLEAP", cal_str) == 0) ||
+             (strcasecmp("NO_LEAP", cal_str) == 0)) {
         return CALENDAR_NOLEAP;
     }
     else if (strcasecmp("365_DAY", cal_str) == 0) {

--- a/vic/vic_run/include/vic_def.h
+++ b/vic/vic_run/include/vic_def.h
@@ -770,7 +770,6 @@ typedef struct {
     unsigned short int calendar;  /**< Date/time calendar */
     unsigned short int time_units;  /**< Units for numeric times */
     double time_origin_num;        /**< Numeric date origin */
-    char caseid[MAXSTRING];      /**< Case ID*/
 } global_param_struct;
 
 /******************************************************************************

--- a/vic/vic_run/include/vic_log.h
+++ b/vic/vic_run/include/vic_log.h
@@ -43,6 +43,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <execinfo.h>
 #include <string.h>
 
 // Set the log level
@@ -63,11 +64,12 @@ void finalize_logging(void);
 void get_current_datetime(char *cdt);
 void get_logname(const char *path, int id, char *filename);
 void initialize_log(void);
+void print_trace(void);
 void setup_logging(int id);
+
 
 // Macros for logging
 #define clean_errno() (errno == 0 ? "None" : strerror(errno))
-#define clean_ncerrno(e) (nc_strerror(e))
 
 // Debug Level
 #if LOG_LVL < 10
@@ -107,16 +109,15 @@ void setup_logging(int id);
 
 // Error Level is always active
 #ifdef NO_LINENOS
-#define log_err(M, ...) fprintf(LOG_DEST, "[ERROR] errno: %s: " M "\n", \
-                                clean_errno(), ## __VA_ARGS__); exit(1);
-#define log_ncerr(e) fprintf(LOG_DEST, "[ERROR] errno: %s \n", \
-                             clean_ncerrno(e)); exit(1);
+#define log_err(M, ...) print_trace(); fprintf(LOG_DEST, \
+                                               "[ERROR] errno: %s: " M "\n", \
+                                               clean_errno(), ## __VA_ARGS__); \
+    exit(1);
 #else
-#define log_err(M, ...) fprintf(LOG_DEST, "[ERROR] %s:%d: errno: %s: " M "\n", \
-                                __FILE__, __LINE__, \
-                                clean_errno(), ## __VA_ARGS__); exit(1);
-#define log_ncerr(e) fprintf(LOG_DEST, "[ERROR] %s:%d: errno: %s \n", __FILE__, \
-                             __LINE__, clean_ncerrno(e)); exit(1);
+#define log_err(M, ...) print_trace(); fprintf(LOG_DEST, \
+                                               "[ERROR] %s:%d: errno: %s: " M "\n", __FILE__, __LINE__, \
+                                               clean_errno(), ## __VA_ARGS__); \
+    exit(1);
 #endif
 
 // These depend on previously defined macros


### PR DESCRIPTION
@apcraig and @bartnijssen -

I've gotten started debugging the CESM driver.  For the most part, things are moving along although I've run into a few issues that I'll discuss here:

- **FIXED**: Fortran string, Fortran character arrays, and C character arrays are not all the same.  My original (naive) implementation was causing all sorts of problems when we were passing strings into C. Here's what I learned / did to fix the problems: we now have a few simple Fortran functions to convert between fortran strings and character arrays (see `Copy_s2a()` and `Copy_a2s()` below) and a C function to trim trailing white/null space (see `trim()` below).  
- **FIXED**: Passing derived types (such as `vic_clock` or `case_metadata`) from Fortran to C can (should) be done by reference. This we don't have to create a pointer to the objects in Fortran, we can just accept the object as a pointer in C.  See `vic_cesm_init` for an example.
- **BROKEN** - We are having issues accessing and using global memory defined at the C level.  I first noticed this when debugging `mpi_map_decomp_domain`.  Although `mpi_size`, which is defined as a `extern int` is set as 64 in the mpi init step, when accessing the same value in `mpi_map_decomp_domain`, the value was undefined (`mpi_size == 1163087445`, yikes!).  I'm also finding that we're having similar issues when accessing the `global_param`, `options`, and `parameters` structures (values are scrambled, even after initialization).  All are defined in the header of `vic_cesm_interface_c.c`.  So, we (I) need to work on figuring this out...