### PR TITLE
add comparisons module

### DIFF
--- a/tests/unit/vic_run/test_comparisons.py
+++ b/tests/unit/vic_run/test_comparisons.py
@@ -4,27 +4,7 @@ import numpy as np
 import pytest
 
 
-def test_assert_almost_equal():
-    xs = [1.0, 2.33333, 33, 77.7, 0.000001]
-    ys = [1.0, 2.33339, 34, 77.70000000001, -0.00001]
-
-    results = {}
-    results[3] = [True, True, False, True, True]
-    results[10] = [True, False, False, True, False]
-    results[12] = [True, False, False, False, False]
-
-    for decimal, rs in iteritems(results):
-        for x, y, r in pyzip(xs, ys, rs):
-            assert vic_lib.assert_almost_equal(x, y, decimal) == r
-            # make sure numpy agrees
-            if not r:
-                with pytest.raises(AssertionError):
-                    np.testing.assert_almost_equal(x, y, decimal=decimal)
-            else:
-                np.testing.assert_almost_equal(x, y, decimal=decimal)
-
-
-def test_assert_close():
+def test_assert_close_float():
     xs = [1e10, 1e-7, 1e10, 1e-8, 1e10, 1e-8, 1.]
     ys = [1.00001e10, 1e-8, 1.00001e10, 1e-9, 1.0001e10, 1e-9, 1.]
 
@@ -35,6 +15,21 @@ def test_assert_close():
     for tols, rs in iteritems(results):
         rtol, abs_tol = tols
         for x, y, r in pyzip(xs, ys, rs):
-            assert vic_lib.assert_close(x, y, rtol, abs_tol) == r
+            assert vic_lib.assert_close_float(x, y, rtol, abs_tol) == r
+            # make sure numpy agrees
+            assert np.isclose(x, y, rtol=rtol, atol=abs_tol) == r
+
+def test_assert_close_double():
+    xs = [1e10, 1e-7, 1e10, 1e-8, 1e10, 1e-8, 1.]
+    ys = [1.00001e10, 1e-8, 1.00001e10, 1e-9, 1.0001e10, 1e-9, 1.]
+
+    results = {}
+    results[(1e-05, 1e-08)] = [True, False, True, True, False, True, True]
+    results[(1e-03, 0)] = [True, False,  True, False,  True, False,  True]
+
+    for tols, rs in iteritems(results):
+        rtol, abs_tol = tols
+        for x, y, r in pyzip(xs, ys, rs):
+            assert vic_lib.assert_close_float(x, y, rtol, abs_tol) == r
             # make sure numpy agrees
             assert np.isclose(x, y, rtol=rtol, atol=abs_tol) == r

--- a/tests/unit/vic_run/test_comparisons.py
+++ b/tests/unit/vic_run/test_comparisons.py
@@ -1,35 +1,23 @@
 from vic import lib as vic_lib
-from vic.pycompat import iteritems, pyzip
+from vic.pycompat import pyzip
 import numpy as np
-import pytest
 
 
 def test_assert_close_float():
-    xs = [1e10, 1e-7, 1e10, 1e-8, 1e10, 1e-8, 1.]
-    ys = [1.00001e10, 1e-8, 1.00001e10, 1e-9, 1.0001e10, 1e-9, 1.]
+    xs = [1e-7, 1e10, 1e-8, 1e10, 1e-8, 1.]
+    ys = [1e-8, 1.00001e10, 1e-9, 1.0001e10, 1e-9, 1.]
 
-    results = {}
-    results[(1e-05, 1e-08)] = [True, False, True, True, False, True, True]
-    results[(1e-03, 0)] = [True, False,  True, False,  True, False,  True]
-
-    for tols, rs in iteritems(results):
-        rtol, abs_tol = tols
+    for (rtol, abs_tol) in [(1e-3, 1e-2), (1e-03, 0)]:
+        rs = np.isclose(xs, ys, rtol, abs_tol)
         for x, y, r in pyzip(xs, ys, rs):
             assert vic_lib.assert_close_float(x, y, rtol, abs_tol) == r
-            # make sure numpy agrees
-            assert np.isclose(x, y, rtol=rtol, atol=abs_tol) == r
+
 
 def test_assert_close_double():
-    xs = [1e10, 1e-7, 1e10, 1e-8, 1e10, 1e-8, 1.]
-    ys = [1.00001e10, 1e-8, 1.00001e10, 1e-9, 1.0001e10, 1e-9, 1.]
+    xs = [1e-7, 1e10, 1e-8, 1e10, 1e-8, 1.]
+    ys = [1e-8, 1.00001e10, 1e-9, 1.0001e10, 1e-9, 1.]
 
-    results = {}
-    results[(1e-05, 1e-08)] = [True, False, True, True, False, True, True]
-    results[(1e-03, 0)] = [True, False,  True, False,  True, False,  True]
-
-    for tols, rs in iteritems(results):
-        rtol, abs_tol = tols
+    for (rtol, abs_tol) in [(1e-05, 1e-08), (1e-03, 0)]:
+        rs = np.isclose(xs, ys, rtol, abs_tol)
         for x, y, r in pyzip(xs, ys, rs):
-            assert vic_lib.assert_close_float(x, y, rtol, abs_tol) == r
-            # make sure numpy agrees
-            assert np.isclose(x, y, rtol=rtol, atol=abs_tol) == r
+            assert vic_lib.assert_close_double(x, y, rtol, abs_tol) == r

--- a/tests/unit/vic_run/test_comparisons.py
+++ b/tests/unit/vic_run/test_comparisons.py
@@ -1,0 +1,40 @@
+from vic import lib as vic_lib
+from vic.pycompat import iteritems, pyzip
+import numpy as np
+import pytest
+
+
+def test_assert_almost_equal():
+    xs = [1.0, 2.33333, 33, 77.7, 0.000001]
+    ys = [1.0, 2.33339, 34, 77.70000000001, -0.00001]
+
+    results = {}
+    results[3] = [True, True, False, True, True]
+    results[10] = [True, False, False, True, False]
+    results[12] = [True, False, False, False, False]
+
+    for decimal, rs in iteritems(results):
+        for x, y, r in pyzip(xs, ys, rs):
+            assert vic_lib.assert_almost_equal(x, y, decimal) == r
+            # make sure numpy agrees
+            if not r:
+                with pytest.raises(AssertionError):
+                    np.testing.assert_almost_equal(x, y, decimal=decimal)
+            else:
+                np.testing.assert_almost_equal(x, y, decimal=decimal)
+
+
+def test_assert_close():
+    xs = [1e10, 1e-7, 1e10, 1e-8, 1e10, 1e-8, 1.]
+    ys = [1.00001e10, 1e-8, 1.00001e10, 1e-9, 1.0001e10, 1e-9, 1.]
+
+    results = {}
+    results[(1e-05, 1e-08)] = [True, False, True, True, False, True, True]
+    results[(1e-03, 0)] = [True, False,  True, False,  True, False,  True]
+
+    for tols, rs in iteritems(results):
+        rtol, abs_tol = tols
+        for x, y, r in pyzip(xs, ys, rs):
+            assert vic_lib.assert_close(x, y, rtol, abs_tol) == r
+            # make sure numpy agrees
+            assert np.isclose(x, y, rtol=rtol, atol=abs_tol) == r

--- a/vic/drivers/python/vic_headers.py
+++ b/vic/drivers/python/vic_headers.py
@@ -1057,6 +1057,8 @@ void alblake(double, double, double *, double *, double *, double *, double,
              double);
 double arno_evap(layer_data_struct *, double, double, double, double, double,
                  double, double, double, double, double, double *);
+bool assert_almost_equal(double x, double y, int decimal);
+bool assert_close(double x, double y, double rtol, double abs_tol);
 double calc_atmos_energy_bal(double, double, double, double, double, double,
                              double, double, double, double, double, double,
                              double, double *, double *, double *, double *,

--- a/vic/drivers/python/vic_headers.py
+++ b/vic/drivers/python/vic_headers.py
@@ -1057,8 +1057,8 @@ void alblake(double, double, double *, double *, double *, double *, double,
              double);
 double arno_evap(layer_data_struct *, double, double, double, double, double,
                  double, double, double, double, double, double *);
-bool assert_almost_equal(double x, double y, int decimal);
-bool assert_close(double x, double y, double rtol, double abs_tol);
+bool assert_close_double(double x, double y, double rtol, double abs_tol);
+bool assert_close_float(float x, float y, float rtol, float abs_tol);
 double calc_atmos_energy_bal(double, double, double, double, double, double,
                              double, double, double, double, double, double,
                              double, double *, double *, double *, double *,

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -42,6 +42,8 @@ void alblake(double, double, double *, double *, double *, double *, double,
              double);
 double arno_evap(layer_data_struct *, double, double, double, double, double,
                  double, double, double, double, double, double *);
+bool assert_almost_equal(double x, double y, int decimal);
+bool assert_close(double x, double y, double rtol, double abs_tol);
 double calc_atmos_energy_bal(double, double, double, double, double, double,
                              double, double, double, double, double, double,
                              double, double *, double *, double *, double *,

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -42,8 +42,8 @@ void alblake(double, double, double *, double *, double *, double *, double,
              double);
 double arno_evap(layer_data_struct *, double, double, double, double, double,
                  double, double, double, double, double, double *);
-bool assert_almost_equal(double x, double y, int decimal);
-bool assert_close(double x, double y, double rtol, double abs_tol);
+bool assert_close_double(double x, double y, double rtol, double abs_tol);
+bool assert_close_float(float x, float y, float rtol, float abs_tol);
 double calc_atmos_energy_bal(double, double, double, double, double, double,
                              double, double, double, double, double, double,
                              double, double *, double *, double *, double *,

--- a/vic/vic_run/src/comparisons.c
+++ b/vic/vic_run/src/comparisons.c
@@ -29,14 +29,15 @@
 #include <vic_def.h>
 
 /******************************************************************************
- * @brief    returns false if two doubles are not equal up to desired precision
+ * @brief    returns false if two floats are not equal up to desired tolerance
  *****************************************************************************/
 bool
-assert_almost_equal(double x,
-                    double y,
-                    int    decimal)
+assert_close_float(float x,
+                   float y,
+                   float rtol,
+                   float abs_tol)
 {
-    if (fabs(x - y) < 0.5 * pow(10, -1 * decimal)) {
+    if (fabs(x - y) <= abs_tol + rtol * fabs(y)) {
         return true;
     }
     return false;
@@ -46,10 +47,10 @@ assert_almost_equal(double x,
  * @brief    returns false if two doubles are not equal up to desired tolerance
  *****************************************************************************/
 bool
-assert_close(double x,
-             double y,
-             double rtol,
-             double abs_tol)
+assert_close_double(double x,
+                    double y,
+                    double rtol,
+                    double abs_tol)
 {
     if (fabs(x - y) <= abs_tol + rtol * fabs(y)) {
         return true;

--- a/vic/vic_run/src/comparisons.c
+++ b/vic/vic_run/src/comparisons.c
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * @section DESCRIPTION
+ *
+ * floating point comparison utilities
+ *
+ * @section LICENSE
+ *
+ * The Variable Infiltration Capacity (VIC) macroscale hydrological model
+ * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * and Environmental Engineering, University of Washington.
+ *
+ * The VIC model is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *****************************************************************************/
+
+#include <stdbool.h>
+#include <math.h>
+#include <vic_def.h>
+
+/******************************************************************************
+ * @brief    returns false if two doubles are not equal up to desired precision
+ *****************************************************************************/
+bool
+assert_almost_equal(double x,
+                    double y,
+                    int    decimal)
+{
+    if (fabs(x - y) < 0.5 * pow(10, -1 * decimal)) {
+        return true;
+    }
+    return false;
+}
+
+/******************************************************************************
+ * @brief    returns false if two doubles are not equal up to desired tolerance
+ *****************************************************************************/
+bool
+assert_close(double x,
+             double y,
+             double rtol,
+             double abs_tol)
+{
+    if (fabs(x - y) <= abs_tol + rtol * fabs(y)) {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
This PR adds a few simple floating point comparison functions, something VIC is desperately in need of. Lines like [this one](https://github.com/UW-Hydro/VIC/blob/develop/vic/drivers/image/src/vic_init.c#L1054) are all over the VIC code base.

I included unit tests for both comparisons but did not go hunting in the code for oportunities to apply the functions, that is for a later date.

If we feel it is necessary, I can add more robust comparisons such as:
- http://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.testing.assert_array_almost_equal_nulp.html#numpy.testing.assert_array_almost_equal_nulp
- http://docs.scipy.org/doc/numpy-dev/reference/generated/numpy.testing.assert_array_max_ulp.html#numpy.testing.assert_array_max_ulp

or relative greater/less or equal to comparisons.

Thoughts?

Refs:
- http://www.cygnus-software.com/papers/comparingfloats/comparingfloats.htm
- https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
- http://stackoverflow.com/questions/5989191/compare-two-floats
- http://floating-point-gui.de/errors/comparison/
- http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html