### PR TITLE
Broadcast global_domain

### DIFF
--- a/vic/drivers/cesm/include/vic_mpi.h
+++ b/vic/drivers/cesm/include/vic_mpi.h
@@ -35,6 +35,7 @@
 // Component MPI Communicator
 MPI_Comm MPI_COMM_VIC;
 
+void create_MPI_domain_struct_type(MPI_Datatype *mpi_type);
 void create_MPI_global_struct_type(MPI_Datatype *mpi_type);
 void create_MPI_location_struct_type(MPI_Datatype *mpi_type);
 void create_MPI_nc_file_struct_type(MPI_Datatype *mpi_type);

--- a/vic/drivers/cesm/src/vic_start.c
+++ b/vic/drivers/cesm/src/vic_start.c
@@ -142,8 +142,8 @@ vic_start(vic_clock     *vclock,
         validate_parameters();
     }
 
-    // broadcast global, option, param structures as well as global valies
-    // such as NF and NR
+    // broadcast global, option, param and domain structures as well as global
+    // values such as NF and NR
     status = MPI_Bcast(&NF, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_VIC);
     if (status != MPI_SUCCESS) {
         log_err("MPI error in vic_start(): %d\n", status);
@@ -170,6 +170,15 @@ vic_start(vic_clock     *vclock,
                        0, MPI_COMM_VIC);
     if (status != MPI_SUCCESS) {
         log_err("MPI error in vic_start(): %d\n", status);
+    }
+
+    status = MPI_Bcast(&global_domain, 1, mpi_domain_type,
+                       0, MPI_COMM_VIC);
+    if (status != MPI_SUCCESS) {
+        log_err("MPI error in vic_start(): %d\n", status);
+    }
+    if (mpi_rank != 0) {
+        global_domain.locations = NULL;
     }
 
     // setup the local domain_structs


### PR DESCRIPTION
Haven't had a chance to compile or run. @jhamman : please review

Problem:
 * global `nx` and `ny` not available on any process other than the master process

Solution:
 * define `MPI_Datatype` for `domain_struct`
 * broadcast `global_domain` (this is already available as a global on all the processes)
 * set `global_domain.locations` to `NULL` for anything other than the master process