### PR TITLE
switched 'xc' and 'yc' in get_global_domain.c

### DIFF
--- a/vic/drivers/image/src/get_global_domain.c
+++ b/vic/drivers/image/src/get_global_domain.c
@@ -112,7 +112,7 @@ get_global_domain(char          *nc_name,
 
     // get longitude -
     // TBD: read var id from file
-    get_nc_field_double(nc_name, "xc",
+    get_nc_field_double(nc_name, "yc",
                         d2start, d2count, var);
     for (i = 0; i < global_domain->ncells; i++) {
         // rescale to [-180., 180]. Note that the if statement is not strictly
@@ -125,7 +125,7 @@ get_global_domain(char          *nc_name,
 
     // get latitude
     // TBD: read var id from file
-    get_nc_field_double(nc_name, "yc",
+    get_nc_field_double(nc_name, "xc",
                         d2start, d2count, var);
     for (i = 0; i < global_domain->ncells; i++) {
         global_domain->locations[i].latitude = (double) var[idx[i]];


### PR DESCRIPTION
xc and yc need to be switched. See also ncdump of Stehekin_image_test.domain.nc:

```
double xc(nj=4, ni=5);
:standard_name = "latitude";
:long_name = "latitude";
:units = "degrees_north";
:axis = "Y";

double yc(nj=4, ni=5);
  :standard_name = "longitude";
  :long_name = "longitude";
  :units = "degrees_east";
  :axis = "X";
```
