### PR TITLE
Added all grid cells to global domain structure.

### DIFF
--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -60,7 +60,8 @@ typedef struct {
  *           model is run on a single processor, then the two are identical.
  *****************************************************************************/
 typedef struct {
-    size_t ncells; /**< number of active grid cells on domain */
+    size_t ncells_total; /**< total number of grid cells on domain */
+    size_t ncells_active; /**< number of active grid cells on domain */
     size_t n_nx; /**< size of x-index; */
     size_t n_ny; /**< size of y-index */
     location_struct *locations; /**< locations structs for local domain */

--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -43,6 +43,7 @@
  *           identical. The model is run over a list of cells.
  *****************************************************************************/
 typedef struct {
+    bool run; /**< TRUE: run grid cell. FALSE: do not run grid cell */
     double latitude; /**< latitude of grid cell center */
     double longitude; /**< longitude of grid cell center */
     double area; /**< area of grid cell */

--- a/vic/drivers/image/src/get_global_domain.c
+++ b/vic/drivers/image/src/get_global_domain.c
@@ -56,7 +56,7 @@ get_global_domain(char          *nc_name,
 
     // get total number of gridcells in domain
     global_domain->ncells_total = global_domain->n_ny * global_domain->n_nx;
-    
+
     // allocate memory for cells to be run
     run = (int *) malloc(global_domain->ncells_total *
                          sizeof(int));

--- a/vic/drivers/image/src/get_global_domain.c
+++ b/vic/drivers/image/src/get_global_domain.c
@@ -39,8 +39,6 @@ get_global_domain(char          *nc_name,
     double *var = NULL;
     size_t  i;
     size_t  j;
-    size_t  x;
-    size_t  y;
     size_t  d2count[2];
     size_t  d2start[2];
 
@@ -65,11 +63,9 @@ get_global_domain(char          *nc_name,
 
     get_nc_field_int(nc_name, "run_cell", d2start, d2count, run);
 
-    for (y = 0, i = 0; y < global_domain->n_ny; y++) {
-        for (x = 0; x < global_domain->n_nx; x++, i++) {
-            if (run[i]) {
-                global_domain->ncells_active++;
-            }
+    for (i = 0; i < global_domain->ncells_total; i++) {
+        if (run[i]) {
+            global_domain->ncells_active++;
         }
     }
 
@@ -89,21 +85,17 @@ get_global_domain(char          *nc_name,
         log_err("Memory allocation error in get_global_domain().");
     }
 
-    for (y = 0, i = 0, j = 0; y < global_domain->n_ny; y++) {
-        for (x = 0; x < global_domain->n_nx; x++, i++) {
-            if (run[i]) {
-                global_domain->locations[i].run = 1;
-            }
+    for (i = 0; i < global_domain->ncells_total; i++) {
+        if (run[i]) {
+            global_domain->locations[i].run = true;
         }
     }
 
-    for (y = 0, i = 0, j = 0; y < global_domain->n_ny; y++) {
-        for (x = 0; x < global_domain->n_nx; x++, i++) {
-            if (run[i]) {
-                global_domain->locations[i].io_idx = i;
-                global_domain->locations[i].global_idx = j;
-                j++;
-            }
+    for (i = 0, j = 0; i < global_domain->ncells_total; i++) {
+        if (run[i]) {
+            global_domain->locations[i].io_idx = i;
+            global_domain->locations[i].global_idx = j;
+            j++;
         }
     }
 
@@ -111,15 +103,13 @@ get_global_domain(char          *nc_name,
     // TBD: read var id from file
     get_nc_field_double(nc_name, "xc",
                         d2start, d2count, var);
-    for (y = 0, i = 0; y < global_domain->n_ny; y++) {
-        for (x = 0; x < global_domain->n_nx; x++, i++) {
-            // rescale to [-180., 180]. Note that the if statement is not strictly
-            // needed, but it prevents -180 from turning into 180 and vice versa
-            if (var[i] < -180.f || var[i] > 180.f) {
-                var[i] -= round(var[i] / 360.f) * 360.f;
-            }
-            global_domain->locations[i].longitude = (double) var[i];
+    for (i = 0; i < global_domain->ncells_total; i++) {
+        // rescale to [-180., 180]. Note that the if statement is not strictly
+        // needed, but it prevents -180 from turning into 180 and vice versa
+        if (var[i] < -180.f || var[i] > 180.f) {
+            var[i] -= round(var[i] / 360.f) * 360.f;
         }
+        global_domain->locations[i].longitude = (double) var[i];
     }
 
     // get latitude

--- a/vic/drivers/image/src/get_global_domain.c
+++ b/vic/drivers/image/src/get_global_domain.c
@@ -54,8 +54,11 @@ get_global_domain(char          *nc_name,
     d2count[0] = global_domain->n_ny;
     d2count[1] = global_domain->n_nx;
 
+    // get total number of gridcells in domain
+    global_domain->ncells_total = global_domain->n_ny * global_domain->n_nx;
+    
     // allocate memory for cells to be run
-    run = (int *) malloc(global_domain->n_ny * global_domain->n_nx *
+    run = (int *) malloc(global_domain->ncells_total *
                          sizeof(int));
     if (run == NULL) {
         log_err("Memory allocation error in get_global_domain().");
@@ -65,8 +68,8 @@ get_global_domain(char          *nc_name,
 
     for (y = 0, i = 0; y < global_domain->n_ny; y++) {
         for (x = 0; x < global_domain->n_nx; x++, i++) {
-            if (run[i] == 1) {
-                global_domain->ncells++;
+            if (run[i] == true) {
+                global_domain->ncells_active++;
             }
         }
     }
@@ -77,12 +80,12 @@ get_global_domain(char          *nc_name,
     if (global_domain->locations == NULL) {
         log_err("Memory allocation error in get_global_domain().");
     }
-    for (i = 0; i < global_domain->n_ny * global_domain->n_nx; i++) {
+    for (i = 0; i < global_domain->ncells_total; i++) {
         initialize_location(&(global_domain->locations[i]));
     }
 
     // allocate memory for variables
-    var = malloc(global_domain->n_ny * global_domain->n_nx *
+    var = malloc(global_domain->ncells_total *
                  sizeof(*var));
     if (var == NULL) {
         log_err("Memory allocation error in get_global_domain().");
@@ -90,7 +93,7 @@ get_global_domain(char          *nc_name,
 
     for (y = 0, i = 0, j = 0; y < global_domain->n_ny; y++) {
         for (x = 0; x < global_domain->n_nx; x++, i++) {
-            if (run[i] == 1) {
+            if (run[i] == true) {
                 global_domain->locations[i].run = 1;
             }
         }
@@ -98,7 +101,7 @@ get_global_domain(char          *nc_name,
 
     for (y = 0, i = 0, j = 0; y < global_domain->n_ny; y++) {
         for (x = 0; x < global_domain->n_nx; x++, i++) {
-            if (run[i] == 1) {
+            if (run[i] == true) {
                 global_domain->locations[i].io_idx = i;
                 global_domain->locations[i].global_idx = j;
                 j++;
@@ -153,7 +156,7 @@ get_global_domain(char          *nc_name,
 
     // print_domain(global_domain, true);
 
-    return global_domain->ncells;
+    return global_domain->ncells_active;
 }
 
 /******************************************************************************
@@ -162,7 +165,8 @@ get_global_domain(char          *nc_name,
 void
 initialize_domain(domain_struct *domain)
 {
-    domain->ncells = 0;
+    domain->ncells_total = 0;
+    domain->ncells_active = 0;
     domain->n_nx = 0;
     domain->n_ny = 0;
     domain->locations = NULL;

--- a/vic/drivers/image/src/print_library_image.c
+++ b/vic/drivers/image/src/print_library_image.c
@@ -70,12 +70,13 @@ print_domain(domain_struct *domain,
     size_t i;
 
     fprintf(LOG_DEST, "domain:\n");
-    fprintf(LOG_DEST, "\tncells   : %zd\n", domain->ncells);
-    fprintf(LOG_DEST, "\tn_nx     : %zd\n", domain->n_nx);
-    fprintf(LOG_DEST, "\tn_ny     : %zd\n", domain->n_ny);
-    fprintf(LOG_DEST, "\tlocations: %p\n", domain->locations);
+    fprintf(LOG_DEST, "\tncells_total : %zd\n", domain->ncells_total);
+    fprintf(LOG_DEST, "\tncells_active: %zd\n", domain->ncells_active);
+    fprintf(LOG_DEST, "\tn_nx         : %zd\n", domain->n_nx);
+    fprintf(LOG_DEST, "\tn_ny         : %zd\n", domain->n_ny);
+    fprintf(LOG_DEST, "\tlocations    : %p\n", domain->locations);
     if (print_loc) {
-        for (i = 0; i < domain->ncells; i++) {
+        for (i = 0; i < domain->ncells_active; i++) {
             print_location(&(domain->locations[i]));
         }
     }

--- a/vic/drivers/image/src/vic_alloc.c
+++ b/vic/drivers/image/src/vic_alloc.c
@@ -50,7 +50,7 @@ vic_alloc(void)
 
     // allocate memory for atmos structure
     atmos = (atmos_data_struct *)
-            malloc((size_t) local_domain.ncells *
+            malloc((size_t) local_domain.ncells_active *
                    sizeof(atmos_data_struct));
     if (atmos == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -58,7 +58,7 @@ vic_alloc(void)
 
     // allocate memory for veg_hist structure
     veg_hist = (veg_hist_struct **)
-               malloc((size_t) local_domain.ncells *
+               malloc((size_t) local_domain.ncells_active *
                       sizeof(veg_hist_struct *));
     if (veg_hist == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -66,7 +66,7 @@ vic_alloc(void)
 
     // allocate memory for soil structure
     soil_con = (soil_con_struct *)
-               malloc((size_t) local_domain.ncells *
+               malloc((size_t) local_domain.ncells_active *
                       sizeof(soil_con_struct));
     if (soil_con == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -74,7 +74,7 @@ vic_alloc(void)
 
     // allocate memory for vegetation mapping structure
     veg_con_map = (veg_con_map_struct *)
-                  malloc((size_t) local_domain.ncells *
+                  malloc((size_t) local_domain.ncells_active *
                          sizeof(veg_con_map_struct));
     if (veg_con_map == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -82,7 +82,7 @@ vic_alloc(void)
 
     // allocate memory for vegetation structure
     veg_con = (veg_con_struct **)
-              malloc((size_t) local_domain.ncells *
+              malloc((size_t) local_domain.ncells_active *
                      sizeof(veg_con_struct *));
     if (veg_con == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -90,7 +90,7 @@ vic_alloc(void)
 
     // allocate memory for vegetation structure
     veg_lib = (veg_lib_struct **)
-              malloc((size_t) local_domain.ncells *
+              malloc((size_t) local_domain.ncells_active *
                      sizeof(veg_lib_struct *));
     if (veg_lib == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -98,7 +98,7 @@ vic_alloc(void)
 
     // all_vars allocation
     all_vars = (all_vars_struct *)
-               malloc((size_t) local_domain.ncells *
+               malloc((size_t) local_domain.ncells_active *
                       sizeof(all_vars_struct));
     if (all_vars == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -106,7 +106,7 @@ vic_alloc(void)
 
     // out_data allocation
     out_data = (out_data_struct **)
-               malloc((size_t) local_domain.ncells *
+               malloc((size_t) local_domain.ncells_active *
                       sizeof(out_data_struct *));
     if (out_data == NULL) {
         log_err("Memory allocation error in vic_alloc().");
@@ -114,14 +114,14 @@ vic_alloc(void)
 
     // save_data allocation
     save_data = (save_data_struct *)
-                malloc((size_t) local_domain.ncells *
+                malloc((size_t) local_domain.ncells_active *
                        sizeof(save_data_struct));
     if (save_data == NULL) {
         log_err("Memory allocation error in vic_alloc().");
     }
 
     // allocate memory for individual grid cells
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         // atmos allocation - allocate enough memory for NR+1 steps
         alloc_atmos(&(atmos[i]));
 

--- a/vic/drivers/image/src/vic_finalize.c
+++ b/vic/drivers/image/src/vic_finalize.c
@@ -72,7 +72,7 @@ vic_finalize(void)
         }
     }
 
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         free_atmos(&(atmos[i]));
         free(soil_con[i].AreaFract);
         free(soil_con[i].BandElev);

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -59,7 +59,7 @@ vic_force(void)
     size_t                     d3start[3];
 
     // allocate memory for variables to be read
-    fvar = (float *) malloc(local_domain.ncells * sizeof(float));
+    fvar = (float *) malloc(local_domain.ncells_active * sizeof(float));
     if (fvar == NULL) {
         log_err("Memory allocation error in vic_force().");
     }
@@ -86,7 +86,7 @@ vic_force(void)
         d3start[0] = global_param.forceoffset[0] + j;
         get_scatter_nc_field_float(filenames.forcing[0], "tas",
                                    d3start, d3count, fvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].air_temp[j] = (double) fvar[i];
         }
     }
@@ -96,7 +96,7 @@ vic_force(void)
         d3start[0] = global_param.forceoffset[0] + j;
         get_scatter_nc_field_float(filenames.forcing[0], "prcp",
                                    d3start, d3count, fvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].prec[j] = (double) fvar[i];
         }
     }
@@ -106,7 +106,7 @@ vic_force(void)
         d3start[0] = global_param.forceoffset[0] + j;
         get_scatter_nc_field_float(filenames.forcing[0], "dswrf",
                                    d3start, d3count, fvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].shortwave[j] = (double) fvar[i];
         }
     }
@@ -116,7 +116,7 @@ vic_force(void)
         d3start[0] = global_param.forceoffset[0] + j;
         get_scatter_nc_field_float(filenames.forcing[0], "dlwrf",
                                    d3start, d3count, fvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].longwave[j] = (double) fvar[i];
         }
     }
@@ -126,7 +126,7 @@ vic_force(void)
         d3start[0] = global_param.forceoffset[0] + j;
         get_scatter_nc_field_float(filenames.forcing[0], "wind",
                                    d3start, d3count, fvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].wind[j] = (double) fvar[i];
         }
     }
@@ -136,7 +136,7 @@ vic_force(void)
         d3start[0] = global_param.forceoffset[0] + j;
         get_scatter_nc_field_float(filenames.forcing[0], "shum",
                                    d3start, d3count, fvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].vp[j] = (double) fvar[i];
         }
     }
@@ -146,7 +146,7 @@ vic_force(void)
         d3start[0] = global_param.forceoffset[0] + j;
         get_scatter_nc_field_float(filenames.forcing[0], "pres",
                                    d3start, d3count, fvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].pressure[j] = (double) fvar[i];
         }
     }
@@ -154,7 +154,7 @@ vic_force(void)
     if (options.LAKES) {
         // Channel inflow to lake
         for (j = 0; j < NF; j++) {
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 atmos[i].channel_in[j] = 0;
             }
         }
@@ -165,7 +165,7 @@ vic_force(void)
             d3start[0] = global_param.forceoffset[0] + j;
             get_scatter_nc_field_float(filenames.forcing[0], "catm",
                                        d3start, d3count, fvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 atmos[i].Catm[j] = (double) fvar[i];
             }
         }
@@ -174,7 +174,7 @@ vic_force(void)
             d3start[0] = global_param.forceoffset[0] + j;
             get_scatter_nc_field_float(filenames.forcing[0], "fdir",
                                        d3start, d3count, fvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 atmos[i].fdir[j] = (double) fvar[i];
             }
         }
@@ -183,7 +183,7 @@ vic_force(void)
             d3start[0] = global_param.forceoffset[0] + j;
             get_scatter_nc_field_float(filenames.forcing[0], "par",
                                        d3start, d3count, fvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 atmos[i].par[j] = (double) fvar[i];
             }
         }
@@ -199,7 +199,7 @@ vic_force(void)
         t_offset = 0;
     }
     // Convert forcings into what we need and calculate missing ones
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         for (j = 0; j < NF; j++) {
             // temperature in Celsius
             atmos[i].air_temp[j] -= CONST_TKFRZ;
@@ -224,7 +224,7 @@ vic_force(void)
 
 
     // Put average value in NR field
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         atmos[i].air_temp[NR] = average(atmos[i].air_temp, NF);
         // For precipitation put total
         atmos[i].prec[NR] = average(atmos[i].prec, NF) * NF;
@@ -252,7 +252,7 @@ vic_force(void)
 
     // Update the veg_hist structure with the current vegetation parameters.
     // Currently only implemented for climatological values in image mode
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         for (v = 0; v < options.NVEGTYPES; v++) {
             vidx = veg_con_map[i].vidx[v];
             if (vidx != -1) {

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -105,6 +105,14 @@ main(int    argc,
     // initialize model parameters from parameter files
     vic_init();
 
+    //////
+// double timetmp;
+// extern dmy_struct         *dmy;
+// timetmp = date2num(global_param.time_origin_num, &dmy[0], 0., global_param.calendar, global_param.time_units);
+// printf("Result: %f\t global_param.time_origin_num: %f\t calendar: %d\t time units: %d\n", timetmp, global_param.time_origin_num, global_param.calendar, global_param.time_units);
+////exit(0);
+    ///////
+
     // restore model state, either using a cold start or from a restart file
     vic_restore();
 

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -105,14 +105,6 @@ main(int    argc,
     // initialize model parameters from parameter files
     vic_init();
 
-    //////
-// double timetmp;
-// extern dmy_struct         *dmy;
-// timetmp = date2num(global_param.time_origin_num, &dmy[0], 0., global_param.calendar, global_param.time_units);
-// printf("Result: %f\t global_param.time_origin_num: %f\t calendar: %d\t time units: %d\n", timetmp, global_param.time_origin_num, global_param.calendar, global_param.time_units);
-////exit(0);
-    ///////
-
     // restore model state, either using a cold start or from a restart file
     vic_restore();
 

--- a/vic/drivers/image/src/vic_image_run.c
+++ b/vic/drivers/image/src/vic_image_run.c
@@ -50,7 +50,7 @@ vic_image_run(void)
 
     size_t                     i;
 
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         vic_run(&(atmos[i]), &(all_vars[i]), &dmy[current], &global_param,
                 &lake_con, &(soil_con[i]), veg_con[i], veg_lib[i], veg_hist[i]);
         put_data(&(all_vars[i]), &(atmos[i]), &(soil_con[i]), veg_con[i],

--- a/vic/drivers/image/src/vic_init.c
+++ b/vic/drivers/image/src/vic_init.c
@@ -71,7 +71,7 @@ vic_init(void)
     dmy = make_dmy(&global_param);
 
     // allocate memory for variables to be read
-    dvar = (double *) malloc(local_domain.ncells *
+    dvar = (double *) malloc(local_domain.ncells_active *
                              sizeof(double));
     if (dvar == NULL) {
         log_err("Memory allocation error in vic_init().");
@@ -109,7 +109,7 @@ vic_init(void)
 
     // TBD: Check that options.NVEGTYPES is the right number. Bare soil is
     // the complicating factor here
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         for (j = 0; j < options.NVEGTYPES; j++) {
             veg_lib[i][j].NVegLibTypes = options.NVEGTYPES;
             veg_lib[i][j].veg_class = (int) j;
@@ -121,7 +121,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "overstory",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].overstory = (int) dvar[i];
         }
     }
@@ -131,7 +131,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "rarc",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].rarc = (double) dvar[i];
         }
     }
@@ -141,7 +141,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "rmin",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].rmin = (double) dvar[i];
         }
     }
@@ -151,7 +151,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "wind_h",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].wind_h = (double) dvar[i];
         }
     }
@@ -161,7 +161,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "RGL",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].RGL = (double)dvar[i];
         }
     }
@@ -171,7 +171,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "rad_atten",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].rad_atten = (double) dvar[i];
         }
     }
@@ -181,7 +181,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "wind_atten",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].wind_atten = (double) dvar[i];
         }
     }
@@ -191,7 +191,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veglib, "trunk_ratio",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_lib[i][j].trunk_ratio = (double) dvar[i];
         }
     }
@@ -203,7 +203,7 @@ vic_init(void)
             d4start[1] = k;
             get_scatter_nc_field_double(filenames.veglib, "LAI",
                                         d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 veg_lib[i][j].LAI[k] = (double) dvar[i];
                 veg_lib[i][j].Wdmax[k] = param.VEG_LAI_WATER_FACTOR *
                                          veg_lib[i][j].LAI[k];
@@ -218,7 +218,7 @@ vic_init(void)
             d4start[1] = k;
             get_scatter_nc_field_double(filenames.veglib, "albedo",
                                         d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 veg_lib[i][j].albedo[k] = (double) dvar[i];
             }
         }
@@ -231,7 +231,7 @@ vic_init(void)
             d4start[1] = k;
             get_scatter_nc_field_double(filenames.veglib, "veg_rough",
                                         d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 veg_lib[i][j].roughness[k] = (double) dvar[i];
             }
         }
@@ -244,7 +244,7 @@ vic_init(void)
             d4start[1] = k;
             get_scatter_nc_field_double(filenames.veglib, "displacement",
                                         d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 veg_lib[i][j].displacement[k] = (double) dvar[i];
             }
         }
@@ -253,7 +253,7 @@ vic_init(void)
     // vegcover not implemented in image model
     for (j = 0; j < options.NVEGTYPES; j++) {
         for (k = 0; k < MONTHS_PER_YEAR; k++) {
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 veg_lib[i][j].vegcover[k] = 1.0;
             }
         }
@@ -264,35 +264,35 @@ vic_init(void)
     // b_infilt
     get_scatter_nc_field_double(filenames.soil, "infilt",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].b_infilt = (double) dvar[i];
     }
 
     // Ds
     get_scatter_nc_field_double(filenames.soil, "Ds",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].Ds = (double) dvar[i];
     }
 
     // Dsmax
     get_scatter_nc_field_double(filenames.soil, "Dsmax",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].Dsmax = (double) dvar[i];
     }
 
     // Ws
     get_scatter_nc_field_double(filenames.soil, "Ws",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].Ws = (double) dvar[i];
     }
 
     // c
     get_scatter_nc_field_double(filenames.soil, "c",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].c = (double) dvar[i];
     }
 
@@ -301,7 +301,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "expt",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].expt[j] = (double) dvar[i];
         }
     }
@@ -311,7 +311,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "Ksat",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].Ksat[j] = (double) dvar[i];
         }
     }
@@ -321,7 +321,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "init_moist",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].init_moist[j] = (double) dvar[i];
         }
     }
@@ -331,7 +331,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "phi_s",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].phi_s[j] = (double) dvar[i];
         }
     }
@@ -339,7 +339,7 @@ vic_init(void)
     // elevation: mean grid cell elevation
     get_scatter_nc_field_double(filenames.soil, "elev",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].elevation = (double) dvar[i];
     }
 
@@ -348,7 +348,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "depth",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].depth[j] = (double) dvar[i];
         }
     }
@@ -356,14 +356,14 @@ vic_init(void)
     // avg_temp: mean grid temperature
     get_scatter_nc_field_double(filenames.soil, "avg_T",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].avg_temp = (double) dvar[i];
     }
 
     // dp: damping depth
     get_scatter_nc_field_double(filenames.soil, "dp",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].dp = (double) dvar[i];
     }
 
@@ -372,7 +372,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "bubble",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].bubble[j] = (double) dvar[i];
         }
     }
@@ -382,7 +382,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "quartz",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].quartz[j] = (double) dvar[i];
         }
     }
@@ -392,7 +392,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "bulk_density",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].bulk_dens_min[j] = (double) dvar[i];
         }
     }
@@ -402,7 +402,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "soil_density",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].soil_dens_min[j] = (double) dvar[i];
         }
     }
@@ -415,7 +415,7 @@ vic_init(void)
             d3start[0] = j;
             get_scatter_nc_field_double(filenames.soil, "organic",
                                         d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 soil_con[i].organic[j] = (double) dvar[i];
             }
         }
@@ -425,7 +425,7 @@ vic_init(void)
             d3start[0] = j;
             get_scatter_nc_field_double(filenames.soil, "bulk_density_org",
                                         d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 soil_con[i].bulk_dens_org[j] = (double) dvar[i];
             }
         }
@@ -435,7 +435,7 @@ vic_init(void)
             d3start[0] = j;
             get_scatter_nc_field_double(filenames.soil, "soil_density_org",
                                         d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 soil_con[i].soil_dens_org[j] = (double) dvar[i];
             }
         }
@@ -447,7 +447,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "Wcr_FRACT",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].Wcr[j] = (double) dvar[i];
         }
     }
@@ -458,7 +458,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "Wpwp_FRACT",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].Wpwp[j] = (double) dvar[i];
         }
     }
@@ -466,21 +466,21 @@ vic_init(void)
     // rough: soil roughness
     get_scatter_nc_field_double(filenames.soil, "rough",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].rough = (double) dvar[i];
     }
 
     // snow_rough: snow roughness
     get_scatter_nc_field_double(filenames.soil, "snow_rough",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].snow_rough = (double) dvar[i];
     }
 
     // annual_prec: annual precipitation
     get_scatter_nc_field_double(filenames.soil, "annual_prec",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].annual_prec = (double) dvar[i];
     }
 
@@ -489,7 +489,7 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.soil, "resid_moist",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].resid_moist[j] = (double) dvar[i];
         }
     }
@@ -497,7 +497,7 @@ vic_init(void)
     // fs_active: frozen soil active flag
     get_scatter_nc_field_double(filenames.soil, "fs_active",
                                 d2start, d2count, dvar);
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         soil_con[i].FS_ACTIVE = (char) dvar[i];
     }
 
@@ -506,14 +506,14 @@ vic_init(void)
         // max_snow_distrib_slope
         get_scatter_nc_field_double(filenames.soil, "max_snow_distrib_slope",
                                     d2start, d2count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].max_snow_distrib_slope = (double) dvar[i];
         }
 
         // frost_slope: slope of frozen soil distribution
         get_scatter_nc_field_double(filenames.soil, "frost_slope",
                                     d2start, d2count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].frost_slope = (double) dvar[i];
         }
     }
@@ -522,13 +522,13 @@ vic_init(void)
         // avgJulyAirTemp: average July air temperature
         get_scatter_nc_field_double(filenames.soil, "avgJulyAirTemp",
                                     d2start, d2count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].avgJulyAirTemp = (double) dvar[i];
         }
     }
 
     // Additional processing of the soil variables
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         for (j = 0; j < options.Nlayer; j++) {
             // compute layer properties
             soil_con[i].bulk_density[j] =
@@ -643,7 +643,7 @@ vic_init(void)
 
     // read_snowband()
     if (options.SNOW_BAND == 1) {
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             soil_con[i].AreaFract[0] = 1.;
             soil_con[i].BandElev[0] = soil_con[i].elevation;
             soil_con[i].Pfactor[0] = 1.;
@@ -656,7 +656,7 @@ vic_init(void)
             d3start[0] = j;
             get_scatter_nc_field_double(filenames.snowband, "AreaFract",
                                         d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 soil_con[i].AreaFract[j] = (double) dvar[i];
             }
         }
@@ -665,7 +665,7 @@ vic_init(void)
             d3start[0] = j;
             get_scatter_nc_field_double(filenames.snowband, "elevation",
                                         d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 soil_con[i].BandElev[j] = (double) dvar[i];
             }
         }
@@ -674,12 +674,12 @@ vic_init(void)
             d3start[0] = j;
             get_scatter_nc_field_double(filenames.snowband, "Pfactor",
                                         d3start, d3count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 soil_con[i].BandElev[j] = (double) dvar[i];
             }
         }
         // Run some checks and corrections for soil
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             // Make sure area fractions are positive and add to 1
             sum = 0.;
             for (j = 0; j < options.SNOW_BAND; j++) {
@@ -768,7 +768,7 @@ vic_init(void)
     }
 
     // logic from compute_treeline()
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         for (j = 0; j < options.SNOW_BAND; j++) {
             // Lapse average annual July air temperature
             if (soil_con[i].avgJulyAirTemp + soil_con[i].Tfactor[j] <=
@@ -791,7 +791,7 @@ vic_init(void)
 
     // number of vegetation types - in vic this is defined without the bare soil
     // and the vegetation above the treeline
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         nveg = veg_con_map[i].nv_active - 1;
         if (options.AboveTreelineVeg >= 0) {
             nveg -= 1;
@@ -809,13 +809,13 @@ vic_init(void)
         d3start[0] = j;
         get_scatter_nc_field_double(filenames.veg, "Cv",
                                     d3start, d3count, dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             veg_con_map[i].Cv[j] = (double) dvar[i];
         }
     }
 
     // do the mapping
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         k = 0;
         for (j = 0; j < options.NVEGTYPES; j++) {
             if (veg_con_map[i].Cv[j] > 0) {
@@ -837,7 +837,7 @@ vic_init(void)
             d4start[1] = k;
             get_scatter_nc_field_double(filenames.veg, "root_depth",
                                         d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 vidx = veg_con_map[i].vidx[j];
                 if (vidx != -1) {
                     veg_con[i][vidx].zone_depth[k] = (double) dvar[i];
@@ -853,7 +853,7 @@ vic_init(void)
             d4start[1] = k;
             get_scatter_nc_field_double(filenames.veg, "root_fract",
                                         d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 vidx = veg_con_map[i].vidx[j];
                 if (vidx != -1) {
                     veg_con[i][vidx].zone_fract[k] = (double) dvar[i];
@@ -863,12 +863,12 @@ vic_init(void)
     }
 
     // calculate root fractions
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         calc_root_fractions(veg_con[i], &(soil_con[i]));
     }
 
     // Run some checks and corrections for vegetation
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         no_overstory = false;
         // Only run to options.NVEGTYPES - 1, since bare soil is the last type
         for (j = 0; j < options.NVEGTYPES - 1; j++) {
@@ -1059,7 +1059,7 @@ vic_init(void)
             for (j = 0; j < options.NVEGTYPES; j++) {
                 vidx = veg_con_map[i].vidx[j];
                 if (vidx != -1) {
-                    veg_con[i][vidx].Cv /= veg_con[i][0].Cv_sum;
+// veg_con[i][vidx].Cv /= veg_con[i][0].Cv_sum;
                 }
             }
             veg_con[i][0].Cv_sum = 1.;
@@ -1078,7 +1078,7 @@ vic_init(void)
     }
 
     // initialize structures with default values
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         nveg = veg_con[i][0].vegetat_type_num;
         initialize_snow(all_vars[i].snow, nveg);
         initialize_soil(all_vars[i].cell, &(soil_con[i]), nveg);

--- a/vic/drivers/image/src/vic_init_output.c
+++ b/vic/drivers/image/src/vic_init_output.c
@@ -55,7 +55,7 @@ vic_init_output(void)
     size_t                     i;
 
     // initialize the output data structures
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         put_data(&(all_vars[i]), &(atmos[i]), &(soil_con[i]), veg_con[i],
                  veg_lib[i], &lake_con, out_data[i], &(save_data[i]),
                  -global_param.nrecs);

--- a/vic/drivers/image/src/vic_mpi_support.c
+++ b/vic/drivers/image/src/vic_mpi_support.c
@@ -416,7 +416,7 @@ create_MPI_location_struct_type(MPI_Datatype *mpi_type)
     MPI_Datatype *mpi_types;
 
     // nitems has to equal the number of elements in global_param_struct
-    nitems = 8;
+    nitems = 9;
     blocklengths = (int *) malloc(nitems * sizeof(int));
     if (blocklengths == NULL) {
         log_err("Memory allocation error in create_MPI_location_struct_type().")
@@ -439,6 +439,10 @@ create_MPI_location_struct_type(MPI_Datatype *mpi_type)
 
     // reset i
     i = 0;
+
+    // size_t run;
+    offsets[i] = offsetof(location_struct, run);
+    mpi_types[i++] = MPI_C_BOOL;
 
     // double latitude;
     offsets[i] = offsetof(location_struct, latitude);

--- a/vic/drivers/image/src/vic_mpi_support.c
+++ b/vic/drivers/image/src/vic_mpi_support.c
@@ -1778,10 +1778,12 @@ gather_put_nc_field_double(char   *nc_name,
     }
     if (mpi_rank == 0) {
         // remap the array
-        map(sizeof(double), global_domain.ncells_active, NULL, mpi_map_mapping_array,
+        map(sizeof(double), global_domain.ncells_active, NULL,
+            mpi_map_mapping_array,
             dvar_gathered, dvar_remapped);
         // expand to full grid size
-        map(sizeof(double), global_domain.ncells_active, NULL, filter_active_cells,
+        map(sizeof(double), global_domain.ncells_active, NULL,
+            filter_active_cells,
             dvar_remapped, dvar);
         // write to file
         put_nc_field_double(nc_name, open, nc_id, fillval, dimids, ndims,
@@ -1859,7 +1861,8 @@ gather_put_nc_field_int(char   *nc_name,
 
     if (mpi_rank == 0) {
         // remap the array
-        map(sizeof(int), global_domain.ncells_active, NULL, mpi_map_mapping_array,
+        map(sizeof(int), global_domain.ncells_active, NULL,
+            mpi_map_mapping_array,
             ivar_gathered, ivar_remapped);
         // expand to full grid size
         map(sizeof(int), global_domain.ncells_active, NULL, filter_active_cells,
@@ -1916,10 +1919,12 @@ get_scatter_nc_field_double(char   *nc_name,
         }
         get_nc_field_double(nc_name, var_name, start, count, dvar);
         // filter the active cells only
-        map(sizeof(double), global_domain.ncells_active, filter_active_cells, NULL,
+        map(sizeof(double), global_domain.ncells_active, filter_active_cells,
+            NULL,
             dvar, dvar_filtered);
         // map to prepare for MPI_Scatterv
-        map(sizeof(double), global_domain.ncells_active, mpi_map_mapping_array, NULL,
+        map(sizeof(double), global_domain.ncells_active, mpi_map_mapping_array,
+            NULL,
             dvar_filtered, dvar_mapped);
         free(dvar);
         free(dvar_filtered);
@@ -1983,10 +1988,12 @@ get_scatter_nc_field_float(char   *nc_name,
         }
         get_nc_field_float(nc_name, var_name, start, count, fvar);
         // filter the active cells only
-        map(sizeof(float), global_domain.ncells_active, filter_active_cells, NULL,
+        map(sizeof(float), global_domain.ncells_active, filter_active_cells,
+            NULL,
             fvar, fvar_filtered);
         // map to prepare for MPI_Scatterv
-        map(sizeof(float), global_domain.ncells_active, mpi_map_mapping_array, NULL,
+        map(sizeof(float), global_domain.ncells_active, mpi_map_mapping_array,
+            NULL,
             fvar_filtered, fvar_mapped);
         free(fvar);
         free(fvar_filtered);
@@ -2053,7 +2060,8 @@ get_scatter_nc_field_int(char   *nc_name,
         map(sizeof(int), global_domain.ncells_active, filter_active_cells, NULL,
             ivar, ivar_filtered);
         // map to prepare for MPI_Scatterv
-        map(sizeof(int), global_domain.ncells_active, mpi_map_mapping_array, NULL,
+        map(sizeof(int), global_domain.ncells_active, mpi_map_mapping_array,
+            NULL,
             ivar_filtered, ivar_mapped);
         free(ivar);
         free(ivar_filtered);

--- a/vic/drivers/image/src/vic_mpi_support.c
+++ b/vic/drivers/image/src/vic_mpi_support.c
@@ -1755,20 +1755,20 @@ gather_put_nc_field_double(char   *nc_name,
         }
 
         dvar_gathered = (double *) malloc(sizeof(double) *
-                                          global_domain.ncells);
+                                          global_domain.ncells_active);
         if (dvar_gathered == NULL) {
             log_err("Memory allocation error in gather_put_nc_field_double().");
         }
 
         dvar_remapped = (double *) malloc(sizeof(double) *
-                                          global_domain.ncells);
+                                          global_domain.ncells_active);
         if (dvar_remapped == NULL) {
             log_err("Memory allocation error in gather_put_nc_field_double().");
         }
     }
     // Gather the results from the nodes, result for the local node is in the
     // array *var (which is a function argument)
-    status = MPI_Gatherv(var, local_domain.ncells, MPI_DOUBLE,
+    status = MPI_Gatherv(var, local_domain.ncells_active, MPI_DOUBLE,
                          dvar_gathered, mpi_map_local_array_sizes,
                          mpi_map_global_array_offsets, MPI_DOUBLE,
                          0, MPI_COMM_WORLD);
@@ -1778,10 +1778,10 @@ gather_put_nc_field_double(char   *nc_name,
     }
     if (mpi_rank == 0) {
         // remap the array
-        map(sizeof(double), global_domain.ncells, NULL, mpi_map_mapping_array,
+        map(sizeof(double), global_domain.ncells_active, NULL, mpi_map_mapping_array,
             dvar_gathered, dvar_remapped);
         // expand to full grid size
-        map(sizeof(double), global_domain.ncells, NULL, filter_active_cells,
+        map(sizeof(double), global_domain.ncells_active, NULL, filter_active_cells,
             dvar_remapped, dvar);
         // write to file
         put_nc_field_double(nc_name, open, nc_id, fillval, dimids, ndims,
@@ -1835,20 +1835,20 @@ gather_put_nc_field_int(char   *nc_name,
         }
 
         ivar_gathered = (int *) malloc(sizeof(int) *
-                                       global_domain.ncells);
+                                       global_domain.ncells_active);
         if (ivar_gathered == NULL) {
             log_err("Memory allocation error in gather_put_nc_field_int().");
         }
 
         ivar_remapped = (int *) malloc(sizeof(int) *
-                                       global_domain.ncells);
+                                       global_domain.ncells_active);
         if (ivar_remapped == NULL) {
             log_err("Memory allocation error in gather_put_nc_field_int().");
         }
     }
     // Gather the results from the nodes, result for the local node is in the
     // array *var (which is a function argument)
-    status = MPI_Gatherv(var, local_domain.ncells, MPI_INT,
+    status = MPI_Gatherv(var, local_domain.ncells_active, MPI_INT,
                          ivar_gathered, mpi_map_local_array_sizes,
                          mpi_map_global_array_offsets, MPI_INT,
                          0, MPI_COMM_WORLD);
@@ -1859,10 +1859,10 @@ gather_put_nc_field_int(char   *nc_name,
 
     if (mpi_rank == 0) {
         // remap the array
-        map(sizeof(int), global_domain.ncells, NULL, mpi_map_mapping_array,
+        map(sizeof(int), global_domain.ncells_active, NULL, mpi_map_mapping_array,
             ivar_gathered, ivar_remapped);
         // expand to full grid size
-        map(sizeof(int), global_domain.ncells, NULL, filter_active_cells,
+        map(sizeof(int), global_domain.ncells_active, NULL, filter_active_cells,
             ivar_remapped, ivar);
         // write to file
         put_nc_field_int(nc_name, open, nc_id, fillval, dimids, ndims,
@@ -1905,21 +1905,21 @@ get_scatter_nc_field_double(char   *nc_name,
             log_err("Memory allocation error in get_scatter_nc_field_double().");
         }
         dvar_filtered = (double *) malloc(sizeof(double) *
-                                          global_domain.ncells);
+                                          global_domain.ncells_active);
         if (dvar_filtered == NULL) {
             log_err("Memory allocation error in get_scatter_nc_field_double().");
         }
         dvar_mapped = (double *) malloc(sizeof(double) *
-                                        global_domain.ncells);
+                                        global_domain.ncells_active);
         if (dvar_mapped == NULL) {
             log_err("Memory allocation error in get_scatter_nc_field_double().");
         }
         get_nc_field_double(nc_name, var_name, start, count, dvar);
         // filter the active cells only
-        map(sizeof(double), global_domain.ncells, filter_active_cells, NULL,
+        map(sizeof(double), global_domain.ncells_active, filter_active_cells, NULL,
             dvar, dvar_filtered);
         // map to prepare for MPI_Scatterv
-        map(sizeof(double), global_domain.ncells, mpi_map_mapping_array, NULL,
+        map(sizeof(double), global_domain.ncells_active, mpi_map_mapping_array, NULL,
             dvar_filtered, dvar_mapped);
         free(dvar);
         free(dvar_filtered);
@@ -1929,7 +1929,7 @@ get_scatter_nc_field_double(char   *nc_name,
     // array *var (which is a function argument)
     status = MPI_Scatterv(dvar_mapped, mpi_map_local_array_sizes,
                           mpi_map_global_array_offsets, MPI_DOUBLE,
-                          var, local_domain.ncells, MPI_DOUBLE,
+                          var, local_domain.ncells_active, MPI_DOUBLE,
                           0, MPI_COMM_WORLD);
     if (status != MPI_SUCCESS) {
         fprintf(stderr, "MPI error in main(): %d\n", status);
@@ -1972,21 +1972,21 @@ get_scatter_nc_field_float(char   *nc_name,
             log_err("Memory allocation error in get_scatter_nc_field_float().");
         }
         fvar_filtered = (float *) malloc(sizeof(float) *
-                                         global_domain.ncells);
+                                         global_domain.ncells_active);
         if (fvar_filtered == NULL) {
             log_err("Memory allocation error in get_scatter_nc_field_float().");
         }
         fvar_mapped = (float *) malloc(sizeof(float) *
-                                       global_domain.ncells);
+                                       global_domain.ncells_active);
         if (fvar_mapped == NULL) {
             log_err("Memory allocation error in get_scatter_nc_field_float().");
         }
         get_nc_field_float(nc_name, var_name, start, count, fvar);
         // filter the active cells only
-        map(sizeof(float), global_domain.ncells, filter_active_cells, NULL,
+        map(sizeof(float), global_domain.ncells_active, filter_active_cells, NULL,
             fvar, fvar_filtered);
         // map to prepare for MPI_Scatterv
-        map(sizeof(float), global_domain.ncells, mpi_map_mapping_array, NULL,
+        map(sizeof(float), global_domain.ncells_active, mpi_map_mapping_array, NULL,
             fvar_filtered, fvar_mapped);
         free(fvar);
         free(fvar_filtered);
@@ -1996,7 +1996,7 @@ get_scatter_nc_field_float(char   *nc_name,
     // array *var (which is a function argument)
     status = MPI_Scatterv(fvar_mapped, mpi_map_local_array_sizes,
                           mpi_map_global_array_offsets, MPI_FLOAT,
-                          var, local_domain.ncells, MPI_FLOAT,
+                          var, local_domain.ncells_active, MPI_FLOAT,
                           0, MPI_COMM_WORLD);
     if (status != MPI_SUCCESS) {
         fprintf(stderr, "MPI error in main(): %d\n", status);
@@ -2039,21 +2039,21 @@ get_scatter_nc_field_int(char   *nc_name,
             log_err("Memory allocation error in get_scatter_nc_field_int().");
         }
         ivar_filtered = (int *) malloc(sizeof(int) *
-                                       global_domain.ncells);
+                                       global_domain.ncells_active);
         if (ivar_filtered == NULL) {
             log_err("Memory allocation error in get_scatter_nc_field_int().");
         }
         ivar_mapped = (int *) malloc(sizeof(int) *
-                                     global_domain.ncells);
+                                     global_domain.ncells_active);
         if (ivar_mapped == NULL) {
             log_err("Memory allocation error in get_scatter_nc_field_int().");
         }
         get_nc_field_int(nc_name, var_name, start, count, ivar);
         // filter the active cells only
-        map(sizeof(int), global_domain.ncells, filter_active_cells, NULL,
+        map(sizeof(int), global_domain.ncells_active, filter_active_cells, NULL,
             ivar, ivar_filtered);
         // map to prepare for MPI_Scatterv
-        map(sizeof(int), global_domain.ncells, mpi_map_mapping_array, NULL,
+        map(sizeof(int), global_domain.ncells_active, mpi_map_mapping_array, NULL,
             ivar_filtered, ivar_mapped);
         free(ivar);
         free(ivar_filtered);
@@ -2063,7 +2063,7 @@ get_scatter_nc_field_int(char   *nc_name,
     // array *var (which is a function argument)
     status = MPI_Scatterv(ivar_mapped, mpi_map_local_array_sizes,
                           mpi_map_global_array_offsets, MPI_INT,
-                          var, local_domain.ncells, MPI_INT,
+                          var, local_domain.ncells_active, MPI_INT,
                           0, MPI_COMM_WORLD);
     if (status != MPI_SUCCESS) {
         fprintf(stderr, "MPI error in main(): %d\n", status);

--- a/vic/drivers/image/src/vic_restore.c
+++ b/vic/drivers/image/src/vic_restore.c
@@ -57,7 +57,7 @@ vic_restore(void)
     }
 
     // run through the remaining VIC initialization routines
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         // TBD: do something sensible for surf_temp
         surf_temp = 0.;
         nveg = veg_con[i][0].vegetat_type_num;

--- a/vic/drivers/image/src/vic_start.c
+++ b/vic/drivers/image/src/vic_start.c
@@ -57,8 +57,6 @@ vic_start(void)
     extern int                 mpi_size;
     extern option_struct       options;
     extern parameters_struct   param;
-    size_t                     x;
-    size_t                     y;
     size_t                     j;
 
     // Initialize global structures
@@ -200,7 +198,7 @@ vic_start(void)
             initialize_location(&(active_locations[i]));
         }
 
-        for (i = 0, j = 0; i < global_domain->ncells_total; i++) {
+        for (i = 0, j = 0; i < global_domain.ncells_total; i++) {
             if (global_domain.locations[i].run) {
                 active_locations[j] = global_domain.locations[i];
                 j++;

--- a/vic/drivers/image/src/vic_start.c
+++ b/vic/drivers/image/src/vic_start.c
@@ -200,13 +200,10 @@ vic_start(void)
             initialize_location(&(active_locations[i]));
         }
 
-        j = 0;
-        for (y = 0, i = 0; y < global_domain.n_ny; y++) {
-            for (x = 0; x < global_domain.n_nx; x++, i++) {
-                if (global_domain.locations[i].run) {
-                    active_locations[j] = global_domain.locations[i];
-                    j++;
-                }
+        for (i = 0, j = 0; i < global_domain->ncells_total; i++) {
+            if (global_domain.locations[i].run) {
+                active_locations[j] = global_domain.locations[i];
+                j++;
             }
         }
 

--- a/vic/drivers/image/src/vic_store.c
+++ b/vic/drivers/image/src/vic_store.c
@@ -69,22 +69,22 @@ vic_store(void)
     grid_size = global_domain.n_ny * global_domain.n_nx;
 
     // allocate memory for variables to be stored
-    cvar = (char *) malloc(local_domain.ncells * sizeof(char));
+    cvar = (char *) malloc(local_domain.ncells_active * sizeof(char));
     if (cvar == NULL) {
         log_err("Memory allocation error in vic_store().");
     }
 
-    ivar = (int *) malloc(local_domain.ncells * sizeof(int));
+    ivar = (int *) malloc(local_domain.ncells_active * sizeof(int));
     if (ivar == NULL) {
         log_err("Memory allocation error in vic_store().");
     }
 
-    dvar = (double *) malloc(local_domain.ncells * sizeof(double));
+    dvar = (double *) malloc(local_domain.ncells_active * sizeof(double));
     if (dvar == NULL) {
         log_err("Memory allocation error in vic_store().");
     }
 
-    fvar = (float *) malloc(local_domain.ncells * sizeof(float));
+    fvar = (float *) malloc(local_domain.ncells_active * sizeof(float));
     if (fvar == NULL) {
         log_err("Memory allocation error in vic_store().");
     }
@@ -134,7 +134,7 @@ vic_store(void)
     initialize_state_file(&nc_state_file);
 
     // set missing values
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         cvar[i] = nc_state_file.c_fillvalue;
         ivar[i] = nc_state_file.i_fillvalue;
         dvar[i] = nc_state_file.d_fillvalue;
@@ -153,7 +153,7 @@ vic_store(void)
     dimids[2] = nc_state_file.ni_dimid;
     for (j = 0; j < options.Nnode; j++) {
         d3start[0] = j;
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             dvar[i] = (double) soil_con[i].dz_node[j];
         }
         gather_put_nc_field_double(nc_state_file.fname, &(nc_state_file.open),
@@ -161,7 +161,7 @@ vic_store(void)
                                    nc_state_file.d_fillvalue,
                                    dimids, ndims, "dz_node", d3start, d3count,
                                    dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             dvar[i] = nc_state_file.d_fillvalue;
         }
     }
@@ -177,7 +177,7 @@ vic_store(void)
     dimids[2] = nc_state_file.ni_dimid;
     for (j = 0; j < options.Nnode; j++) {
         d3start[0] = j;
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             dvar[i] = (double) soil_con[i].Zsum_node[j];
         }
         gather_put_nc_field_double(nc_state_file.fname, &(nc_state_file.open),
@@ -185,7 +185,7 @@ vic_store(void)
                                    nc_state_file.d_fillvalue,
                                    dimids, ndims, "Zsum_node", d3start, d3count,
                                    dvar);
-        for (i = 0; i < local_domain.ncells; i++) {
+        for (i = 0; i < local_domain.ncells_active; i++) {
             dvar[i] = nc_state_file.d_fillvalue;
         }
     }
@@ -206,7 +206,7 @@ vic_store(void)
             d5start[1] = k;
             for (j = 0; j < options.Nlayer; j++) {
                 d5start[2] = j;
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     v = veg_con_map[i].vidx[k];
                     if (v >= 0) {
                         dvar[i] = (double)
@@ -222,7 +222,7 @@ vic_store(void)
                                            nc_state_file.d_fillvalue,
                                            dimids, ndims, "Soil_moisture",
                                            d5start, d5count, dvar);
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     dvar[i] = nc_state_file.d_fillvalue;
                 }
             }
@@ -248,7 +248,7 @@ vic_store(void)
                 d6start[2] = j;
                 for (p = 0; p < options.Nfrost; p++) {
                     d6start[3] = p;
-                    for (i = 0; i < local_domain.ncells; i++) {
+                    for (i = 0; i < local_domain.ncells_active; i++) {
                         v = veg_con_map[i].vidx[k];
                         if (v >= 0) {
                             dvar[i] = (double)
@@ -264,7 +264,7 @@ vic_store(void)
                                                nc_state_file.d_fillvalue,
                                                dimids, ndims, "Ice_content",
                                                d6start, d6count, dvar);
-                    for (i = 0; i < local_domain.ncells; i++) {
+                    for (i = 0; i < local_domain.ncells_active; i++) {
                         dvar[i] = nc_state_file.d_fillvalue;
                     }
                 }
@@ -285,7 +285,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -301,7 +301,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Wdew",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -321,7 +321,7 @@ vic_store(void)
             d4start[0] = m;
             for (k = 0; k < options.NVEGTYPES; k++) {
                 d4start[1] = k;
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     v = veg_con_map[i].vidx[k];
                     if (v >= 0) {
                         dvar[i] = (double)
@@ -337,7 +337,7 @@ vic_store(void)
                                            nc_state_file.d_fillvalue,
                                            dimids, ndims, "AnnualNPP",
                                            d4start, d4count, dvar);
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     dvar[i] = nc_state_file.d_fillvalue;
                 }
             }
@@ -356,7 +356,7 @@ vic_store(void)
             d4start[0] = m;
             for (k = 0; k < options.NVEGTYPES; k++) {
                 d4start[1] = k;
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     v = veg_con_map[i].vidx[k];
                     if (v >= 0) {
                         dvar[i] = (double)
@@ -372,7 +372,7 @@ vic_store(void)
                                            nc_state_file.d_fillvalue,
                                            dimids, ndims, "AnnualNPPPrev",
                                            d4start, d4count, dvar);
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     dvar[i] = nc_state_file.d_fillvalue;
                 }
             }
@@ -391,7 +391,7 @@ vic_store(void)
             d4start[0] = m;
             for (k = 0; k < options.NVEGTYPES; k++) {
                 d4start[1] = k;
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     v = veg_con_map[i].vidx[k];
                     if (v >= 0) {
                         dvar[i] = (double)
@@ -407,7 +407,7 @@ vic_store(void)
                                            nc_state_file.d_fillvalue,
                                            dimids, ndims, "CLitter",
                                            d4start, d4count, dvar);
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     dvar[i] = nc_state_file.d_fillvalue;
                 }
             }
@@ -426,7 +426,7 @@ vic_store(void)
             d4start[0] = m;
             for (k = 0; k < options.NVEGTYPES; k++) {
                 d4start[1] = k;
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     v = veg_con_map[i].vidx[k];
                     if (v >= 0) {
                         dvar[i] = (double)
@@ -442,7 +442,7 @@ vic_store(void)
                                            nc_state_file.d_fillvalue,
                                            dimids, ndims, "Cinter",
                                            d4start, d4count, dvar);
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     dvar[i] = nc_state_file.d_fillvalue;
                 }
             }
@@ -461,7 +461,7 @@ vic_store(void)
             d4start[0] = m;
             for (k = 0; k < options.NVEGTYPES; k++) {
                 d4start[1] = k;
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     v = veg_con_map[i].vidx[k];
                     if (v >= 0) {
                         dvar[i] = (double)
@@ -477,7 +477,7 @@ vic_store(void)
                                            nc_state_file.d_fillvalue,
                                            dimids, ndims, "CSlow",
                                            d4start, d4count, dvar);
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     dvar[i] = nc_state_file.d_fillvalue;
                 }
             }
@@ -497,7 +497,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     ivar[i] = (int)
@@ -513,7 +513,7 @@ vic_store(void)
                                     nc_state_file.i_fillvalue,
                                     dimids, ndims, "Last_snow",
                                     d4start, d4count, ivar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 ivar[i] = nc_state_file.i_fillvalue;
             }
         }
@@ -532,7 +532,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     ivar[i] = (int)
@@ -548,7 +548,7 @@ vic_store(void)
                                     nc_state_file.i_fillvalue,
                                     dimids, ndims, "Melt_state",
                                     d4start, d4count, ivar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 ivar[i] = nc_state_file.i_fillvalue;
             }
         }
@@ -567,7 +567,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -583,7 +583,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_coverage",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -602,7 +602,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -618,7 +618,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_water_equivalent",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -637,7 +637,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -653,7 +653,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_surf_temp",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -672,7 +672,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -688,7 +688,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_surf_water",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -707,7 +707,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -723,7 +723,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_pack_temp",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -742,7 +742,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -758,7 +758,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_pack_water",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -777,7 +777,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -793,7 +793,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_density",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -812,7 +812,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -828,7 +828,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_cold_content",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -847,7 +847,7 @@ vic_store(void)
         d4start[0] = m;
         for (k = 0; k < options.NVEGTYPES; k++) {
             d4start[1] = k;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 v = veg_con_map[i].vidx[k];
                 if (v >= 0) {
                     dvar[i] = (double)
@@ -863,7 +863,7 @@ vic_store(void)
                                        nc_state_file.d_fillvalue,
                                        dimids, ndims, "Snow_canopy",
                                        d4start, d4count, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_state_file.d_fillvalue;
             }
         }
@@ -885,7 +885,7 @@ vic_store(void)
             d5start[1] = k;
             for (j = 0; j < options.Nnode; j++) {
                 d5start[2] = j;
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     v = veg_con_map[i].vidx[k];
                     if (v >= 0) {
                         dvar[i] = (double)
@@ -901,7 +901,7 @@ vic_store(void)
                                            nc_state_file.d_fillvalue,
                                            dimids, ndims, "Node_temperature",
                                            d5start, d5count, dvar);
-                for (i = 0; i < local_domain.ncells; i++) {
+                for (i = 0; i < local_domain.ncells_active; i++) {
                     dvar[i] = nc_state_file.d_fillvalue;
                 }
             }

--- a/vic/drivers/image/src/vic_store.c
+++ b/vic/drivers/image/src/vic_store.c
@@ -49,7 +49,6 @@ vic_store(void)
     size_t                     k;
     size_t                     m;
     size_t                     p;
-    size_t                     grid_size;
     size_t                     ndims;
     char                      *cvar = NULL;
     int                       *ivar = NULL;
@@ -65,8 +64,6 @@ vic_store(void)
     size_t                     d6start[6];
 
     nc_file_struct             nc_state_file;
-
-    grid_size = global_domain.n_ny * global_domain.n_nx;
 
     // allocate memory for variables to be stored
     cvar = malloc(local_domain.ncells_active * sizeof(*cvar));

--- a/vic/drivers/image/src/vic_write.c
+++ b/vic/drivers/image/src/vic_write.c
@@ -36,7 +36,6 @@ void
 vic_write(void)
 {
     extern out_data_struct **out_data;
-    extern domain_struct     global_domain;
     extern domain_struct     local_domain;
     extern nc_file_struct    nc_hist_file;
     extern nc_var_struct     nc_vars[N_OUTVAR_TYPES];
@@ -45,13 +44,11 @@ vic_write(void)
     size_t                   i;
     size_t                   j;
     size_t                   k;
-    size_t                   grid_size;
     size_t                   ndims;
     double                  *dvar = NULL;
     size_t                   dcount[MAXDIMS];
     size_t                   dstart[MAXDIMS];
 
-    grid_size = global_domain.n_ny * global_domain.n_nx;
 
     // allocate memory for variables to be stored
     dvar = malloc(local_domain.ncells_active * sizeof(*dvar));

--- a/vic/drivers/image/src/vic_write.c
+++ b/vic/drivers/image/src/vic_write.c
@@ -54,13 +54,13 @@ vic_write(void)
     grid_size = global_domain.n_ny * global_domain.n_nx;
 
     // allocate memory for variables to be stored
-    dvar = (double *) malloc(local_domain.ncells * sizeof(double));
+    dvar = (double *) malloc(local_domain.ncells_active * sizeof(double));
     if (dvar == NULL) {
         log_err("Memory allocation error in vic_write().");
     }
 
     // set missing values
-    for (i = 0; i < local_domain.ncells; i++) {
+    for (i = 0; i < local_domain.ncells_active; i++) {
         dvar[i] = nc_hist_file.d_fillvalue;
     }
 
@@ -91,7 +91,7 @@ vic_write(void)
         for (j = 0; j < out_data[0][k].nelem; j++) {
             // if there is more than one layer, then dstart needs to advance
             dstart[1] = j;
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = (double) out_data[i][k].aggdata[j];
             }
             gather_put_nc_field_double(nc_hist_file.fname, &(nc_hist_file.open),
@@ -99,7 +99,7 @@ vic_write(void)
                                        nc_hist_file.d_fillvalue,
                                        dimids, ndims, nc_vars[k].nc_var_name,
                                        dstart, dcount, dvar);
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 dvar[i] = nc_hist_file.d_fillvalue;
             }
         }
@@ -115,7 +115,7 @@ vic_write(void)
     // reset the agg data
     for (k = 0; k < N_OUTVAR_TYPES; k++) {
         for (j = 0; j < out_data[0][k].nelem; j++) {
-            for (i = 0; i < local_domain.ncells; i++) {
+            for (i = 0; i < local_domain.ncells_active; i++) {
                 out_data[i][k].aggdata[j] = 0;
             }
         }

--- a/vic/vic_run/src/CalcBlowingSnow.c
+++ b/vic/vic_run/src/CalcBlowingSnow.c
@@ -272,18 +272,18 @@ CalcBlowingSnow(double   Dt,
  *****************************************************************************/
 double
 qromb(double (*funcd)(),
-      double es,
-      double Wind,
-      double AirDens,
-      double ZO,
-      double EactAir,
-      double F,
-      double hsalt,
-      double phi_r,
-      double ushear,
-      double Zrh,
-      double a,
-      double b)
+      double   es,
+      double   Wind,
+      double   AirDens,
+      double   ZO,
+      double   EactAir,
+      double   F,
+      double   hsalt,
+      double   phi_r,
+      double   ushear,
+      double   Zrh,
+      double   a,
+      double   b)
 {
     extern parameters_struct param;
 
@@ -366,19 +366,19 @@ polint(double  xa[],
  *****************************************************************************/
 double
 trapzd(double (*funcd)(),
-       double es,
-       double Wind,
-       double AirDens,
-       double ZO,
-       double EactAir,
-       double F,
-       double hsalt,
-       double phi_r,
-       double ushear,
-       double Zrh,
-       double a,
-       double b,
-       int    n)
+       double   es,
+       double   Wind,
+       double   AirDens,
+       double   ZO,
+       double   EactAir,
+       double   F,
+       double   hsalt,
+       double   phi_r,
+       double   ushear,
+       double   Zrh,
+       double   a,
+       double   b,
+       int      n)
 {
     double        x, tnm, sum, del;
     static double s;
@@ -545,7 +545,7 @@ sub_with_height(double z,
     fluctuat_v = 0.005 * pow(Wind, 1.36);
 
     // Ventilation velocity for turbulent suspension Lee (1975)
-    Vtz = terminal_v + 3.*fluctuat_v*cos(CONST_PI / 4.);
+    Vtz = terminal_v + 3. * fluctuat_v * cos(CONST_PI / 4.);
 
     Re = 2. * Rmean * Vtz / param.BLOWING_KIN_VIS;
     Nu = 1.79 + 0.606 * pow(Re, 0.5);

--- a/vic/vic_run/src/lakes.eb.c
+++ b/vic/vic_run/src/lakes.eb.c
@@ -2078,7 +2078,7 @@ water_balance(lake_var_struct *lake,
         lake->runoff_out = 0.0;
     }
     else {
-        circum = 2*CONST_PI*pow(surfacearea / CONST_PI, 0.5);
+        circum = 2 * CONST_PI * pow(surfacearea / CONST_PI, 0.5);
         lake->runoff_out = lake_con.wfrac * circum * dt *
                            1.6 * pow(ldepth - lake_con.mindepth, 1.5);
         if ((lake->volume - lake->ice_water_eq) >= lake->runoff_out) {

--- a/vic/vic_run/src/photosynth.c
+++ b/vic/vic_run/src/photosynth.c
@@ -184,8 +184,8 @@ photosynth(char    Ctype,
            !   which is not considered in INITVEGDATA
            ! K scales of course with EK
         ********************************************************************************/
-        K = CO2Specificity * 1.E3 *NscaleFactor *exp(
-            param.PHOTO_EK*(T0 / T1) / (CONST_RGAS * T));
+        K = CO2Specificity * 1.E3 * NscaleFactor * exp(
+            param.PHOTO_EK * (T0 / T1) / (CONST_RGAS * T));
 
         /********************************************************************************
            !  Compute 'dark' respiration

--- a/vic/vic_run/src/root_brent.c
+++ b/vic/vic_run/src/root_brent.c
@@ -291,7 +291,7 @@ root_brent(double LowerBound,
             fc = fa;
         }
 
-        tol = 2 *DBL_EPSILON *fabs(b) + param.ROOT_BRENT_T;
+        tol = 2 * DBL_EPSILON * fabs(b) + param.ROOT_BRENT_T;
         m = 0.5 * (c - b);
 
         if (fabs(m) <= tol || fb == 0) {


### PR DESCRIPTION
Added a `run` member to the locations struct.
During domain composition, only the active gridcells are stored in the local domain structs.

See issue: #313

" @wietsefranssen and @jhamman have been discussing how to get all the domain information into the output files. It seems like it will be best to store all grid cells (active and not) in the global domain and then, during the domain decomposition, only store the active grid cells. An run member will be added to the domain structure.
"