### PR TITLE
buffer overflow fix

### DIFF
--- a/vic/drivers/shared/include/vic_driver_shared.h
+++ b/vic/drivers/shared/include/vic_driver_shared.h
@@ -402,7 +402,7 @@ typedef struct {
  * @brief   This structure stores output information for one variable.
  *****************************************************************************/
 typedef struct {
-    char varname[20];        /**< name of variable */
+    char varname[30];        /**< name of variable */
     bool write;              /**< FALSE = don't write; TRUE = write */
     char format[10];         /**< format, when written to an ascii file;
                                 should match the desired fprintf format specifier, e.g. %.4f */


### PR DESCRIPTION
Changed the size of char `varname[20];` to `char varname[30];` in `vic_driver_shared.h`. This has to be done because some strings in `output_list_utils.c` are longer than 20 and this will cause buffer overflows.
