### PR TITLE
deprecate options in image driver.

### DIFF
--- a/samples/global.param.sample.image.txt
+++ b/samples/global.param.sample.image.txt
@@ -5,7 +5,6 @@
 #######################################################################
 # Simulation Parameters
 #######################################################################
-NLAYER		3	# number of soil layers
 NODES		10	# number of soil thermal nodes
 MODEL_STEPS_PER_DAY 	8	# number of model time steps per day (set to 1 if FULL_ENERGY = FALSE, set to > 1 if FULL_ENERGY = TRUE)
 SNOW_STEPS_PER_DAY	8	# number of time steps per day for which to solve the snow model (should = MODEL_STEPS_PER_DAY if MODEL_STEPS_PER_DAY > 1)
@@ -154,8 +153,6 @@ SNOW_BAND	1	# Number of snow bands; if number of snow bands > 1, you must insert
 #######################################################################
 #LAKES		(put lake parameter path/file here)	# Lake parameter path/file
 #LAKE_PROFILE	FALSE	# TRUE = User-specified depth-area parameters in lake parameter file; FALSE = VIC computes a parabolic depth-area profile
-#EQUAL_AREA	FALSE	# TRUE = grid cells are from an equal-area projection; FALSE = grid cells are on a regular lat-lon grid
-#RESOLUTION	0.125	# Grid cell resolution (degrees if EQUAL_AREA is FALSE, km^2 if EQUAL_AREA is TRUE); ignored if LAKES is FALSE
 
 #######################################################################
 # Output Files and Parameters
@@ -163,20 +160,16 @@ SNOW_BAND	1	# Number of snow bands; if number of snow bands > 1, you must insert
 RESULT_DIR      (put the result directory path here)	# Results directory path
 OUTPUT_STEPS_PER_DAY        0       # Output interval (hours); if 0, OUTPUT_STEPS_PER_DAY = MODEL_STEPS_PER_DAY
 SKIPYEAR 	0	# Number of years of output to omit from the output files
-COMPRESS	FALSE	# TRUE = compress input and output files when done
-BINARY_OUTPUT	FALSE	# TRUE = binary output files
 ALMA_OUTPUT	FALSE	# TRUE = ALMA-format output files; FALSE = standard VIC units
 MOISTFRACT 	FALSE	# TRUE = output soil moisture as volumetric fraction; FALSE = standard VIC units
-PRT_HEADER	FALSE   # TRUE = insert a header at the beginning of each output file; FALSE = no header
 PRT_SNOW_BAND   FALSE   # TRUE = write a "snowband" output file, containing band-specific values of snow variables; NOTE: this is ignored if N_OUTFILES is specified below.
 
 #######################################################################
 #
 # Output File Contents
 #
-# As of VIC 4.0.6 and 4.1.0, you can specify your output file names and
-# contents # in the global param file (see the README.txt file for more
-# information).
+# You can specify your output file names and contents # in the global param
+# file (see the VIC documentation file for more information).
 #
 # If you do not specify file names and contents in the global param
 # file, VIC will produce the same set of output files that it has
@@ -184,11 +177,6 @@ PRT_SNOW_BAND   FALSE   # TRUE = write a "snowband" output file, containing band
 # "fdepth" files if FROZEN_SOIL is TRUE and "snowband" files if
 # PRT_SNOW_BAND is TRUE.  These files will have the same contents and
 # format as in earlier versions.
-#
-# The OPTIMIZE and LDAS_OUTPUT options have been removed.  These
-# output configurations can be selected with the proper set of
-# instructions in the global param file.  (see the output.*.template
-# files included in this distribution for more information.)
 #
 # If you do specify the file names and contents in the global param file,
 # PRT_SNOW_BAND will have no effect.
@@ -198,14 +186,14 @@ PRT_SNOW_BAND   FALSE   # TRUE = write a "snowband" output file, containing band
 #   N_OUTFILES    <n_outfiles>
 #
 #   OUTFILE       <prefix>
-#   OUTVAR        <varname>       [<format>        <type>  <multiplier>]
-#   OUTVAR        <varname>       [<format>        <type>  <multiplier>]
-#   OUTVAR        <varname>       [<format>        <type>  <multiplier>]
+#   OUTVAR        <varname>
+#   OUTVAR        <varname>
+#   OUTVAR        <varname>
 #
 #   OUTFILE       <prefix>
-#   OUTVAR        <varname>       [<format>        <type>  <multiplier>]
-#   OUTVAR        <varname>       [<format>        <type>  <multiplier>]
-#   OUTVAR        <varname>       [<format>        <type>  <multiplier>]
+#   OUTVAR        <varname>
+#   OUTVAR        <varname>
+#   OUTVAR        <varname>
 #
 #
 # where
@@ -214,27 +202,4 @@ PRT_SNOW_BAND   FALSE   # TRUE = write a "snowband" output file, containing band
 #                  and longitude
 #   <varname>    = name of the variable (this must be one of the
 #                  output variable names listed in vic_driver_shared.h.)
-#   <format>     = (for ascii output files) fprintf format string,
-#                  e.g.
-#                    %.4f = floating point with 4 decimal places
-#                    %.7e = scientific notation w/ 7 decimal places
-#                    *    = use the default format for this variable
-#
-#   <format>, <type>, and <multiplier> are optional.  For a given
-#   variable, you can specify either NONE of these, or ALL of
-#   these.  If these are omitted, the default values will be used.
-#
-#   <type>       = (for binary output files) data type code.
-#                  Must be one of:
-#                    OUT_TYPE_DOUBLE = double-precision floating point
-#                    OUT_TYPE_FLOAT  = single-precision floating point
-#                    OUT_TYPE_INT    = integer
-#                    OUT_TYPE_USINT  = unsigned short integer
-#                    OUT_TYPE_SINT   = short integer
-#                    OUT_TYPE_CHAR   = char
-#                    *               = use the default type
-#   <multiplier> = (for binary output files) factor to multiply
-#                  the data by before writing, to increase precision.
-#                    *    = use the default multiplier for this variable
-#
 #######################################################################

--- a/samples/global.param.sample.image.txt
+++ b/samples/global.param.sample.image.txt
@@ -167,8 +167,8 @@ PRT_SNOW_BAND   FALSE   # TRUE = write a "snowband" output file, containing band
 #
 # Output File Contents
 #
-# You can specify your output file names and contents # in the global param
-# file (see the VIC documentation file for more information).
+# Specify output file names and contents in the global param file (see the
+# VIC documentation file for more information).
 #
 # If you do not specify file names and contents in the global param
 # file, VIC will produce the same set of output files that it has

--- a/tests/unit/shared/test_vic_time.py
+++ b/tests/unit/shared/test_vic_time.py
@@ -7,8 +7,7 @@ from vic.vic import ffi
 from vic import lib as vic_lib
 
 try:
-    from netcdftime import (netcdftime, utime, JulianDayFromDate,
-                            DateFromJulianDay)
+    from netcdftime import (netcdftime, utime, JulianDayFromDate)
     from netcdftime.netcdftime import (_NoLeapDayFromDate,
                                        _AllLeapFromDate, _360DayFromDate)
     nctime_unavailable = False
@@ -135,68 +134,64 @@ def test_date2num(feb3_noon, dmy_feb_3_noon):
 
 
 @pytest.mark.skipif(nctime_unavailable, reason=nc_reason)
-def test_dmy_julian_day():
+def test_dmy_julian_day(feb3_noon):
     dmy_struct = ffi.new("dmy_struct *")
-    now = datetime.datetime.now()
+    expected = feb3_noon
     for cal in ['julian', 'standard', 'gregorian', 'proleptic_gregorian']:
-        now_jd = JulianDayFromDate(now, calendar=cal)
-        vic_lib.dmy_julian_day(now_jd, calendars[cal], dmy_struct)
+        expected_jd = JulianDayFromDate(expected, calendar=cal)
+        vic_lib.dmy_julian_day(expected_jd, calendars[cal], dmy_struct)
         actual = dmy_to_datetime(dmy_struct)
         # assert that the difference is less than one second
-        assert abs(now - actual) < datetime.timedelta(seconds=1)
+        assert abs(expected - actual) < datetime.timedelta(seconds=1)
 
 
 @pytest.mark.skipif(nctime_unavailable, reason=nc_reason)
 def test_dmy_julian_day_timeseries():
-    # Regression test for GH298
-    jday = JulianDayFromDate(datetime.datetime(1980, 1, 1))
-    dt = np.float(1./24.)  # hourly timestep
-
+    # Regression test for GH298, updated to handle all standard calendars
     dmy_struct = ffi.new("dmy_struct *")
 
-    # for cal in ['julian', 'standard', 'gregorian', 'proleptic_gregorian']:
-    for cal in ['standard']:
-        cal_num = calendars[cal]
-        for i in range(30):
-            expected = DateFromJulianDay(jday, calendar=cal)
-            vic_lib.dmy_julian_day(jday, cal_num, dmy_struct)
+    for cal in ['standard', 'gregorian', 'proleptic_gregorian']:
+        dates = pd.date_range('1970-01-01', '1975-12-31', freq='6H').to_pydatetime()
+        for expected in dates:
+            expected_jday = JulianDayFromDate(expected)
+            vic_lib.dmy_julian_day(expected_jday, calendars[cal], dmy_struct)
             actual = dmy_to_datetime(dmy_struct)
+            print(cal, expected_jday, expected, actual)
             # assert that the difference is less than one second
             assert abs(expected - actual) < datetime.timedelta(seconds=1)
-            jday += dt
 
 
 @pytest.mark.skipif(nctime_unavailable, reason=nc_reason)
-def test_dmy_no_leap_day():
+def test_dmy_no_leap_day(feb3_noon):
     dmy_struct = ffi.new("dmy_struct *")
-    now = datetime.datetime.now()
-    now_jd = _NoLeapDayFromDate(now)
-    vic_lib.dmy_no_leap_day(now_jd, dmy_struct)
+    expected = feb3_noon
+    expected_jd = _NoLeapDayFromDate(expected)
+    vic_lib.dmy_no_leap_day(expected_jd, dmy_struct)
     actual = dmy_to_datetime(dmy_struct)
     # assert that the difference is less than one second
-    assert abs(now - actual) < datetime.timedelta(seconds=1)
+    assert abs(expected - actual) < datetime.timedelta(seconds=1)
 
 
 @pytest.mark.skipif(nctime_unavailable, reason=nc_reason)
-def test_dmy_all_leap():
+def test_dmy_all_leap(feb3_noon):
     dmy_struct = ffi.new("dmy_struct *")
-    now = datetime.datetime.now()
-    now_jd = _AllLeapFromDate(now)
-    vic_lib.dmy_all_leap(now_jd, dmy_struct)
+    expected = feb3_noon
+    expected_jd = _AllLeapFromDate(expected)
+    vic_lib.dmy_all_leap(expected_jd, dmy_struct)
     actual = dmy_to_datetime(dmy_struct)
     # assert that the difference is less than one second
-    assert abs(now - actual) < datetime.timedelta(seconds=1)
+    assert abs(expected - actual) < datetime.timedelta(seconds=1)
 
 
 @pytest.mark.skipif(nctime_unavailable, reason=nc_reason)
-def test_dmy_all_30_day():
+def test_dmy_all_30_day(feb3_noon):
     dmy_struct = ffi.new("dmy_struct *")
-    now = datetime.datetime.now()
-    now_jd = _360DayFromDate(now)
-    vic_lib.dmy_all_30_day(now_jd, dmy_struct)
+    expected = feb3_noon
+    expected_jd = _360DayFromDate(expected)
+    vic_lib.dmy_all_30_day(expected_jd, dmy_struct)
     actual = dmy_to_datetime(dmy_struct)
     # assert that the difference is less than one second
-    assert abs(now - actual) < datetime.timedelta(seconds=1)
+    assert abs(expected - actual) < datetime.timedelta(seconds=1)
 
 
 @pytest.mark.skipif(nctime_unavailable, reason=nc_reason)

--- a/tests/unit/shared/test_vic_time.py
+++ b/tests/unit/shared/test_vic_time.py
@@ -268,3 +268,32 @@ def test_dt_seconds_to_time_units():
         dt_time_units[0] = 0.
         vic_lib.dt_seconds_to_time_units(units[tu], 3600, dt_time_units)
         assert dt_time_units[0] > 0.
+
+
+def test_calendar_from_chars():
+    for cal, expected in calendars.items():
+        actual = vic_lib.calendar_from_chars(ffi.new('char[]', cal.lower().encode()))
+        assert actual == expected
+
+        actual = vic_lib.calendar_from_chars(ffi.new('char[]', cal.upper().encode()))
+        assert actual == expected
+
+
+def timeunits_from_chars():
+    for unit, expected in units.items():
+        actual = vic_lib.calendar_from_chars(ffi.new('char[]', unit.lower().encode()))
+        assert actual == expected
+        actual = vic_lib.calendar_from_chars(ffi.new('char[]', unit.upper().encode()))
+        assert actual == expected
+
+
+def test_parse_nc_time_units():
+    actual_unit = ffi.new('unsigned short int *')
+    actual_dmy = ffi.new('dmy_struct *')
+    unit_chars = ffi.new('char[]', b'days since 0001-01-01')
+    vic_lib.parse_nc_time_units(ffi.addressof(unit_chars), actual_unit, actual_dmy)
+    assert actual_unit[0] == units['days']
+    assert actual_dmy[0].year == 1
+    assert actual_dmy[0].month == 1
+    assert actual_dmy[0].day == 1
+    assert actual_dmy[0].dayseconds == 0

--- a/vic/drivers/classic/src/get_global_param.c
+++ b/vic/drivers/classic/src/get_global_param.c
@@ -116,54 +116,11 @@ get_global_param(FILE *gp)
             }
             else if (strcasecmp("CALENDAR", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("STANDARD", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_STANDARD;
-                }
-                else if (strcasecmp("GREGORIAN", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_GREGORIAN;
-                }
-                else if (strcasecmp("PROLEPTIC_GREGORIAN", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_PROLEPTIC_GREGORIAN;
-                }
-                else if (strcasecmp("NOLEAP", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_NOLEAP;
-                }
-                else if (strcasecmp("365_DAY", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_365_DAY;
-                }
-                else if (strcasecmp("360_DAY", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_360_DAY;
-                }
-                else if (strcasecmp("JULIAN", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_JULIAN;
-                }
-                else if (strcasecmp("ALL_LEAP", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_ALL_LEAP;
-                }
-                else if (strcasecmp("366_DAY", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_366_DAY;
-                }
-                else {
-                    log_err("Unknown calendar specified: %s", flgstr);
-                }
+                global_param.calendar = calendar_from_chars(flgstr);
             }
             else if (strcasecmp("OUT_TIME_UNITS", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("SECONDS", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_SECONDS;
-                }
-                else if (strcasecmp("MINUTES", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_MINUTES;
-                }
-                else if (strcasecmp("HOURS", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_HOURS;
-                }
-                else if (strcasecmp("DAYS", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_DAYS;
-                }
-                else {
-                    log_err("Unknown time units specified: %s", flgstr);
-                }
+                global_param.time_units = timeunits_from_chars(flgstr);
             }
             else if (strcasecmp("FULL_ENERGY", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
@@ -427,12 +384,14 @@ get_global_param(FILE *gp)
                     options.RC_MODE = RC_JARVIS;
                 }
             }
+
             /*************************************
                Define log directory
             *************************************/
             else if (strcasecmp("LOG_DIR", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", filenames.log_path);
             }
+
             /*************************************
                Define state files
             *************************************/
@@ -468,6 +427,7 @@ get_global_param(FILE *gp)
                     options.BINARY_STATE_FILE = true;
                 }
             }
+
             /*************************************
                Define forcing files
             *************************************/
@@ -544,6 +504,7 @@ get_global_param(FILE *gp)
             else if (strcasecmp("WIND_H", optstr) == 0) {
                 sscanf(cmdstr, "%*s %lf", &global_param.wind_h);
             }
+
             /*************************************
                Define parameter files
             *************************************/
@@ -744,6 +705,7 @@ get_global_param(FILE *gp)
                     options.LAKE_PROFILE = true;
                 }
             }
+
             /*************************************
                Define output files
             *************************************/
@@ -810,6 +772,7 @@ get_global_param(FILE *gp)
                     options.PRT_SNOW_BAND = false;
                 }
             }
+
             /*************************************
                Define output file contents
             *************************************/
@@ -822,8 +785,9 @@ get_global_param(FILE *gp)
             else if (strcasecmp("OUTVAR", optstr) == 0) {
                 ; // do nothing
             }
+
             /*************************************
-               Fail when depreciated options are used.
+               Fail when deprecated options are used.
             *************************************/
             else if (strcasecmp("TIME_STEP", optstr) == 0) {
                 log_err("TIME_STEP has been replaced with MODEL_STEPS_PER_DAY, "
@@ -841,6 +805,7 @@ get_global_param(FILE *gp)
                 log_err("FORCE_DT has been replaced with FORCE_STEPS_PER_DAY, "
                         "update your global parameter file accordingly");
             }
+
             /***********************************
                Unrecognized Global Parameter Flag
             ***********************************/

--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -143,7 +143,7 @@ size_t get_global_domain(char *fname, domain_struct *global_domain);
 void get_global_param(FILE *);
 size_t get_nc_dimension(char *nc_name, char *dim_name);
 void get_nc_var_attr(char *nc_name, char *var_name, char *attr_name,
-                     char *attr);
+                     char **attr);
 int get_nc_varndimensions(char *nc_name, char *var_name);
 int get_nc_field_double(char *nc_name, char *var_name, size_t *start,
                         size_t *count, double *var);

--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -138,9 +138,12 @@ double average(double *ar, size_t n);
 out_data_struct *create_output_list(void);
 void free_atmos(atmos_data_struct *atmos);
 void free_veg_hist(veg_hist_struct *veg_hist);
+void get_forcing_file_info(param_set_struct *param_set, size_t file_num);
 size_t get_global_domain(char *fname, domain_struct *global_domain);
 void get_global_param(FILE *);
 size_t get_nc_dimension(char *nc_name, char *dim_name);
+void get_nc_var_attr(char *nc_name, char *var_name, char *attr_name,
+                     char *attr);
 int get_nc_varndimensions(char *nc_name, char *var_name);
 int get_nc_field_double(char *nc_name, char *var_name, size_t *start,
                         size_t *count, double *var);

--- a/vic/drivers/image/include/vic_mpi.h
+++ b/vic/drivers/image/include/vic_mpi.h
@@ -28,6 +28,7 @@
 #define VIC_MPI_H
 
 #include <stddef.h> // used for offsetof() macro
+#include <stdbool.h>  // used for bool types
 #include <mpi.h>
 
 void create_MPI_filenames_struct_type(MPI_Datatype *mpi_type);

--- a/vic/drivers/image/src/get_global_param.c
+++ b/vic/drivers/image/src/get_global_param.c
@@ -70,10 +70,7 @@ get_global_param(FILE *gp)
             /*************************************
                Get Model Global Parameters
             *************************************/
-            if (strcasecmp("NLAYER", optstr) == 0) {
-                sscanf(cmdstr, "%*s %zu", &options.Nlayer);
-            }
-            else if (strcasecmp("NODES", optstr) == 0) {
+            if (strcasecmp("NODES", optstr) == 0) {
                 sscanf(cmdstr, "%*s %zu", &options.Nnode);
             }
             else if (strcasecmp("MODEL_STEPS_PER_DAY", optstr) == 0) {
@@ -111,54 +108,11 @@ get_global_param(FILE *gp)
             }
             else if (strcasecmp("CALENDAR", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("STANDARD", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_STANDARD;
-                }
-                else if (strcasecmp("GREGORIAN", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_GREGORIAN;
-                }
-                else if (strcasecmp("PROLEPTIC_GREGORIAN", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_PROLEPTIC_GREGORIAN;
-                }
-                else if (strcasecmp("NOLEAP", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_NOLEAP;
-                }
-                else if (strcasecmp("365_DAY", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_365_DAY;
-                }
-                else if (strcasecmp("360_DAY", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_360_DAY;
-                }
-                else if (strcasecmp("JULIAN", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_JULIAN;
-                }
-                else if (strcasecmp("ALL_LEAP", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_ALL_LEAP;
-                }
-                else if (strcasecmp("366_DAY", flgstr) == 0) {
-                    global_param.calendar = CALENDAR_366_DAY;
-                }
-                else {
-                    log_err("Unknown calendar specified: %s", flgstr);
-                }
+                global_param.calendar = calendar_from_chars(flgstr);
             }
             else if (strcasecmp("OUT_TIME_UNITS", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("SECONDS", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_SECONDS;
-                }
-                else if (strcasecmp("MINUTES", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_MINUTES;
-                }
-                else if (strcasecmp("HOURS", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_HOURS;
-                }
-                else if (strcasecmp("DAYS", flgstr) == 0) {
-                    global_param.time_units = TIME_UNITS_DAYS;
-                }
-                else {
-                    log_err("Unknown time units specified: %s", flgstr);
-                }
+                global_param.time_units = timeunits_from_chars(flgstr);
             }
             else if (strcasecmp("FULL_ENERGY", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
@@ -309,15 +263,6 @@ get_global_param(FILE *gp)
                     options.CLOSE_ENERGY = false;
                 }
             }
-            else if (strcasecmp("CONTINUEONERROR", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("TRUE", flgstr) == 0) {
-                    options.CONTINUEONERROR = true;
-                }
-                else {
-                    options.CONTINUEONERROR = false;
-                }
-            }
             else if (strcasecmp("COMPUTE_TREELINE", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
                 if (strcasecmp("FALSE", flgstr) == 0) {
@@ -327,18 +272,6 @@ get_global_param(FILE *gp)
                     options.COMPUTE_TREELINE = true;
                     options.AboveTreelineVeg = atoi(flgstr);
                 }
-            }
-            else if (strcasecmp("EQUAL_AREA", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("TRUE", flgstr) == 0) {
-                    options.EQUAL_AREA = true;
-                }
-                else {
-                    options.EQUAL_AREA = false;
-                }
-            }
-            else if (strcasecmp("RESOLUTION", optstr) == 0) {
-                sscanf(cmdstr, "%*s %lf", &global_param.resolution);
             }
             else if (strcasecmp("AERO_RESIST_CANSNOW", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
@@ -456,15 +389,6 @@ get_global_param(FILE *gp)
             else if (strcasecmp("STATEDAY", optstr) == 0) {
                 sscanf(cmdstr, "%*s %hu", &global_param.stateday);
             }
-            else if (strcasecmp("BINARY_STATE_FILE", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("FALSE", flgstr) == 0) {
-                    options.BINARY_STATE_FILE = false;
-                }
-                else {
-                    options.BINARY_STATE_FILE = true;
-                }
-            }
 
             /*************************************
                Define forcing files
@@ -485,51 +409,8 @@ get_global_param(FILE *gp)
                 }
                 file_num = 1;
             }
-            else if (strcasecmp("FORCE_FORMAT", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp(flgstr, "BINARY") == 0) {
-                    param_set.FORCE_FORMAT[file_num] = BINARY;
-                }
-                else if (strcasecmp(flgstr, "ASCII") == 0) {
-                    param_set.FORCE_FORMAT[file_num] = ASCII;
-                }
-                else {
-                    log_err("FORCE_FORMAT must be either ASCII or BINARY.");
-                }
-            }
-            else if (strcasecmp("FORCE_ENDIAN", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp(flgstr, "LITTLE") == 0) {
-                    param_set.FORCE_ENDIAN[file_num] = LITTLE;
-                }
-                else if (strcasecmp(flgstr, "BIG") == 0) {
-                    param_set.FORCE_ENDIAN[file_num] = BIG;
-                }
-                else {
-                    log_err("FORCE_ENDIAN must be either BIG or LITTLE.");
-                }
-            }
             else if (strcasecmp("N_TYPES", optstr) == 0) {
                 sscanf(cmdstr, "%*s %zu", &param_set.N_TYPES[file_num]);
-            }
-            else if (strcasecmp("FORCE_STEPS_PER_DAY", optstr) == 0) {
-                sscanf(cmdstr, "%*s %zu",
-                       &param_set.force_steps_per_day[file_num]);
-            }
-            else if (strcasecmp("FORCEYEAR", optstr) == 0) {
-                sscanf(cmdstr, "%*s %hu", &global_param.forceyear[file_num]);
-            }
-            else if (strcasecmp("FORCEMONTH", optstr) == 0) {
-                sscanf(cmdstr, "%*s %hu", &global_param.forcemonth[file_num]);
-            }
-            else if (strcasecmp("FORCEDAY", optstr) == 0) {
-                sscanf(cmdstr, "%*s %hu", &global_param.forceday[file_num]);
-            }
-            else if (strcasecmp("FORCESEC", optstr) == 0) {
-                sscanf(cmdstr, "%*s %u", &global_param.forcesec[file_num]);
-            }
-            else if (strcasecmp("GRID_DECIMAL", optstr) == 0) {
-                sscanf(cmdstr, "%*s %hu", &options.GRID_DECIMAL);
             }
             else if (strcasecmp("WIND_H", optstr) == 0) {
                 sscanf(cmdstr, "%*s %lf", &global_param.wind_h);
@@ -716,24 +597,6 @@ get_global_param(FILE *gp)
             else if (strcasecmp("DOMAIN_LAT_VAR", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", options.DOMAIN_LAT_VAR);
             }
-            else if (strcasecmp("COMPRESS", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("TRUE", flgstr) == 0) {
-                    options.COMPRESS = true;
-                }
-                else {
-                    options.COMPRESS = false;
-                }
-            }
-            else if (strcasecmp("BINARY_OUTPUT", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("TRUE", flgstr) == 0) {
-                    options.BINARY_OUTPUT = true;
-                }
-                else {
-                    options.BINARY_OUTPUT = false;
-                }
-            }
             else if (strcasecmp("ALMA_OUTPUT", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
                 if (strcasecmp("TRUE", flgstr) == 0) {
@@ -750,15 +613,6 @@ get_global_param(FILE *gp)
                 }
                 else {
                     options.MOISTFRACT = false;
-                }
-            }
-            else if (strcasecmp("PRT_HEADER", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", flgstr);
-                if (strcasecmp("TRUE", flgstr) == 0) {
-                    options.PRT_HEADER = true;
-                }
-                else {
-                    options.PRT_HEADER = false;
                 }
             }
             else if (strcasecmp("PRT_SNOW_BAND", optstr) == 0) {
@@ -794,7 +648,7 @@ get_global_param(FILE *gp)
             }
 
             /*************************************
-               Fail when depreciated options are used.
+               Fail when deprecated options are used.
             *************************************/
             else if (strcasecmp("TIME_STEP", optstr) == 0) {
                 log_err("TIME_STEP has been replaced with MODEL_STEPS_PER_DAY, "
@@ -811,6 +665,57 @@ get_global_param(FILE *gp)
             else if (strcasecmp("FORCE_DT", optstr) == 0) {
                 log_err("FORCE_DT has been replaced with FORCE_STEPS_PER_DAY, "
                         "update your global parameter file accordingly");
+            }
+            else if (strcasecmp("NLAYER", optstr) == 0) {
+                log_err("NLAYER has been deprecated in the image driver");
+            }
+            else if (strcasecmp("FORCE_FORMAT", optstr) == 0) {
+                log_err("FORCE_FORMAT has been deprecated in the image driver");
+            }
+            else if (strcasecmp("FORCE_ENDIAN", optstr) == 0) {
+                log_err("FORCE_ENDIAN has been deprecated in the image driver");
+            }
+            else if (strcasecmp("GRID_DECIMAL", optstr) == 0) {
+                log_err("GRID_DECIMAL has been deprecated in the image driver");
+            }
+            else if (strcasecmp("BINARY_STATE_FILE", optstr) == 0) {
+                log_err(
+                    "BINARY_STATE_FILE has been deprecated in the image driver");
+            }
+            else if (strcasecmp("RESOLUTION", optstr) == 0) {
+                log_err("RESOLUTION has been deprecated in the image driver");
+            }
+            else if (strcasecmp("EQUAL_AREA", optstr) == 0) {
+                log_err("EQUAL_AREA has been deprecated in the image driver");
+            }
+            else if (strcasecmp("CONTINUEONERROR", optstr) == 0) {
+                log_err(
+                    "CONTINUEONERROR has been deprecated in the image driver");
+            }
+            else if (strcasecmp("BINARY_OUTPUT", optstr) == 0) {
+                log_err("BINARY_OUTPUT has been deprecated in the image driver");
+            }
+            else if (strcasecmp("COMPRESS", optstr) == 0) {
+                log_err("COMPRESS has been deprecated in the image driver");
+            }
+            else if (strcasecmp("PRT_HEADER", optstr) == 0) {
+                log_err("PRT_HEADER has been deprecated in the image driver");
+            }
+            else if (strcasecmp("FORCE_STEPS_PER_DAY", optstr) == 0) {
+                log_err(
+                    "FORCE_STEPS_PER_DAY has been deprecated in the image driver");
+            }
+            else if (strcasecmp("FORCEYEAR", optstr) == 0) {
+                log_err("FORCEYEAR has been deprecated in the image driver");
+            }
+            else if (strcasecmp("FORCEMONTH", optstr) == 0) {
+                log_err("FORCEMONTH has been deprecated in the image driver");
+            }
+            else if (strcasecmp("FORCEDAY", optstr) == 0) {
+                log_err("FORCEDAY has been deprecated in the image driver");
+            }
+            else if (strcasecmp("FORCESEC", optstr) == 0) {
+                log_err("FORCESEC has been deprecated in the image driver");
             }
 
             /*************************************
@@ -1106,6 +1011,17 @@ get_global_param(FILE *gp)
         log_err("No forcing file has been defined.  Make sure that the global "
                 "file defines FORCING1.");
     }
+
+    // Get information from the forcing file(s)
+    sprintf(filenames.forcing[0], "%s%4d.nc", filenames.f_path_pfx[0],
+            global_param.startyear);
+    get_forcing_file_info(&param_set, 0);
+    if (param_set.N_TYPES[1] != MISSING) {
+        sprintf(filenames.forcing[1], "%s%4d.nc", filenames.f_path_pfx[1],
+                global_param.startyear);
+        get_forcing_file_info(&param_set, 1);
+    }
+
     if (param_set.N_TYPES[1] != MISSING && global_param.forceyear[1] == 0) {
         global_param.forceyear[1] = global_param.forceyear[0];
         global_param.forcemonth[1] = global_param.forcemonth[0];
@@ -1301,23 +1217,6 @@ get_global_param(FILE *gp)
                     "and QUICK_FLUX=FALSE");
         }
     }
-    if ((options.FULL_ENERGY ||
-         options.FROZEN_SOIL) && options.Nlayer < 3) {
-        log_err("You must define at least 3 soil moisture layers to run "
-                "the model in FULL_ENERGY or FROZEN_SOIL modes.  "
-                "Currently Nlayers is set to  %zu.", options.Nlayer);
-    }
-    if ((!options.FULL_ENERGY &&
-         !options.FROZEN_SOIL) && options.Nlayer < 1) {
-        log_err("You must define at least 1 soil moisture layer to run "
-                "the model.  Currently Nlayers is set to  %zu.",
-                options.Nlayer);
-    }
-    if (options.Nlayer > MAX_LAYERS) {
-        log_err("Global file wants more soil moisture layers (%zu) than "
-                "are defined by MAX_LAYERS (%d).  Edit vic_driver_shared.h and "
-                "recompile.", options.Nlayer, MAX_LAYERS);
-    }
     if (options.Nnode > MAX_NODES) {
         log_err("Global file wants more soil thermal nodes (%zu) than "
                 "are defined by MAX_NODES (%d).  Edit vic_driver_shared.h and "
@@ -1347,16 +1246,6 @@ get_global_param(FILE *gp)
                     "file has been defined.  Make sure that the global "
                     "file defines the lake parameter file on the line that "
                     "begins with \"LAKES\".");
-        }
-        if (global_param.resolution == 0) {
-            log_err("The model grid cell resolution (RESOLUTION) must be "
-                    "defined in the global control file when the lake "
-                    "model is active.");
-        }
-        if (global_param.resolution > 360 && !options.EQUAL_AREA) {
-            log_err("For EQUAL_AREA=FALSE, the model grid cell resolution "
-                    "(RESOLUTION) must be set to the number of lat or lon "
-                    "degrees per grid cell.  This cannot exceed 360.");
         }
         if (options.COMPUTE_TREELINE) {
             log_err("LAKES = TRUE and COMPUTE_TREELINE = TRUE are "

--- a/vic/drivers/image/src/get_nc_var_attr.c
+++ b/vic/drivers/image/src/get_nc_var_attr.c
@@ -61,7 +61,7 @@ get_nc_var_attr(char *nc_name,
     }
 
     // allocate memory for attribute
-    *attr = malloc((attr_len + 1) * sizeof **attr);
+    *attr = malloc((attr_len + 1) * sizeof(**attr));
 
     // read attribute text
     status = nc_get_att_text(nc_id, var_id, attr_name, *attr);

--- a/vic/drivers/image/src/get_nc_var_attr.c
+++ b/vic/drivers/image/src/get_nc_var_attr.c
@@ -1,0 +1,68 @@
+/******************************************************************************
+ * @section DESCRIPTION
+ *
+ * Get netCDF variable attribute.
+ *
+ * @section LICENSE
+ *
+ * The Variable Infiltration Capacity (VIC) macroscale hydrological model
+ * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * and Environmental Engineering, University of Washington.
+ *
+ * The VIC model is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *****************************************************************************/
+
+#include <vic_def.h>
+#include <vic_run.h>
+#include <vic_driver_image.h>
+
+/******************************************************************************
+ * @brief    Get netCDF dimension.
+ *****************************************************************************/
+void
+get_nc_var_attr(char *nc_name,
+                char *var_name,
+                char *attr_name,
+                char *attr)
+{
+    int nc_id;
+    int var_id;
+    int status;
+
+    // open the netcdf file
+    status = nc_open(nc_name, NC_NOWRITE, &nc_id);
+    if (status != NC_NOERR) {
+        log_err("Error opening %s", nc_name);
+    }
+
+    // get variable id
+    status = nc_inq_varid(nc_id, var_name, &var_id);
+    if (status != NC_NOERR) {
+        log_err("Error getting variable id %s in %s", var_name, nc_name);
+    }
+
+    // get number of dimensions
+    status = nc_get_att_text(nc_id, var_id, attr_name, attr);
+    if (status != NC_NOERR) {
+        log_err("Error getting netCDF attribute %s for var %s in %s", attr_name,
+                var_name, nc_name);
+    }
+
+    // close the netcdf file
+    status = nc_close(nc_id);
+    if (status != NC_NOERR) {
+        log_err("Error closing %s", nc_name);
+    }
+}

--- a/vic/drivers/image/src/get_nc_var_attr.c
+++ b/vic/drivers/image/src/get_nc_var_attr.c
@@ -35,11 +35,12 @@ void
 get_nc_var_attr(char *nc_name,
                 char *var_name,
                 char *attr_name,
-                char *attr)
+                char **attr)
 {
-    int nc_id;
-    int var_id;
-    int status;
+    int    nc_id;
+    int    var_id;
+    int    status;
+    size_t attr_len;
 
     // open the netcdf file
     status = nc_open(nc_name, NC_NOWRITE, &nc_id);
@@ -53,8 +54,17 @@ get_nc_var_attr(char *nc_name,
         log_err("Error getting variable id %s in %s", var_name, nc_name);
     }
 
-    // get number of dimensions
-    status = nc_get_att_text(nc_id, var_id, attr_name, attr);
+    // get size of the attribute
+    status = nc_inq_attlen(nc_id, var_id, attr_name, &attr_len);
+    if (status != NC_NOERR) {
+        log_err("Error getting attribute length for %s:%s in %s", var_name, attr_name, nc_name);
+    }
+
+    // allocate memory for attribute
+    *attr = malloc((attr_len + 1) * sizeof **attr);
+
+    // read attribute text
+    status = nc_get_att_text(nc_id, var_id, attr_name, *attr);
     if (status != NC_NOERR) {
         log_err("Error getting netCDF attribute %s for var %s in %s", attr_name,
                 var_name, nc_name);

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -400,8 +400,8 @@ get_forcing_file_info(param_set_struct *param_set,
     double                     nc_time_origin;
     size_t                     start = 0;
     size_t                     count = 2;
-    char                       nc_unit_chars[MAXSTRING];
-    char                       calendar_char[MAXSTRING];
+    char                      *nc_unit_chars = NULL;
+    char                      *calendar_char = NULL;
     unsigned short int         time_units;
     unsigned short int         calendar;
     dmy_struct                 nc_origin_dmy;
@@ -409,8 +409,8 @@ get_forcing_file_info(param_set_struct *param_set,
 
     // read time info from netcdf file
     get_nc_field_double(filenames.forcing[0], "time", &start, &count, nc_times);
-    get_nc_var_attr(filenames.forcing[0], "time", "units", nc_unit_chars);
-    get_nc_var_attr(filenames.forcing[0], "time", "calendar", calendar_char);
+    get_nc_var_attr(filenames.forcing[0], "time", "units", &nc_unit_chars);
+    get_nc_var_attr(filenames.forcing[0], "time", "calendar", &calendar_char);
 
     // parse the calendar string and check to make sure it matches the global clock
     calendar = calendar_from_chars(calendar_char);
@@ -432,19 +432,19 @@ get_forcing_file_info(param_set_struct *param_set,
     // calculate timestep in forcing file
     if (time_units == TIME_UNITS_DAYS) {
         param_set->force_steps_per_day[file_num] =
-            (size_t) (1. / (nc_times[1] - nc_times[0]));
+            (size_t) nearbyint(1. / (nc_times[1] - nc_times[0]));
     }
     else if (time_units == TIME_UNITS_HOURS) {
         param_set->force_steps_per_day[file_num] =
-            (size_t) HOURS_PER_DAY / (nc_times[1] - nc_times[0]);
+            (size_t) nearbyint(HOURS_PER_DAY / (nc_times[1] - nc_times[0]));
     }
     else if (time_units == TIME_UNITS_MINUTES) {
         param_set->force_steps_per_day[file_num] =
-            (size_t) MIN_PER_DAY / (nc_times[1] - nc_times[0]);
+            (size_t) nearbyint(MIN_PER_DAY / (nc_times[1] - nc_times[0]));
     }
     else if (time_units == TIME_UNITS_SECONDS) {
         param_set->force_steps_per_day[file_num] =
-            (size_t) SEC_PER_DAY / (nc_times[1] - nc_times[0]);
+            (size_t) nearbyint(SEC_PER_DAY / (nc_times[1] - nc_times[0]));
     }
 
     // check that this forcing file will work
@@ -459,4 +459,9 @@ get_forcing_file_info(param_set_struct *param_set,
         log_err("Calendar in forcing file does not match the calendar of "
                 "VIC's clock: %s", calendar_char);
     }
+
+    // Free attribute character arrays
+    free(nc_unit_chars);
+    free(calendar_char);
+
 }

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -385,3 +385,78 @@ vic_force(void)
     // cleanup
     free(dvar);
 }
+
+/******************************************************************************
+ * @brief    Determine timestep and start year, month, day, and seconds of forcing files
+ *****************************************************************************/
+void
+get_forcing_file_info(param_set_struct *param_set,
+                      size_t            file_num)
+{
+    extern global_param_struct global_param;
+    extern filenames_struct    filenames;
+
+    double                     nc_times[2];
+    double                     nc_time_origin;
+    size_t                     start = 0;
+    size_t                     count = 2;
+    char                       nc_unit_chars[MAXSTRING];
+    char                       calendar_char[MAXSTRING];
+    unsigned short int         time_units;
+    unsigned short int         calendar;
+    dmy_struct                 nc_origin_dmy;
+    dmy_struct                 nc_start_dmy;
+
+    // read time info from netcdf file
+    get_nc_field_double(filenames.forcing[0], "time", &start, &count, nc_times);
+    get_nc_var_attr(filenames.forcing[0], "time", "units", nc_unit_chars);
+    get_nc_var_attr(filenames.forcing[0], "time", "calendar", calendar_char);
+
+    // parse the calendar string and check to make sure it matches the global clock
+    calendar = calendar_from_chars(calendar_char);
+
+    // parse the time units
+    parse_nc_time_units(nc_unit_chars, &time_units, &nc_origin_dmy);
+
+    // Get date/time of the first entry in the forcing file.
+    nc_time_origin = date2num(0., &nc_origin_dmy, 0., calendar, time_units);
+    num2date(nc_time_origin, nc_times[0], 0., calendar, time_units,
+             &nc_start_dmy);
+
+    // Assign file start date/time
+    global_param.forceyear[file_num] = nc_start_dmy.year;
+    global_param.forcemonth[file_num] = nc_start_dmy.month;
+    global_param.forceday[file_num] = nc_start_dmy.day;
+    global_param.forcesec[file_num] = nc_start_dmy.dayseconds;
+
+    // calculate timestep in forcing file
+    if (time_units == TIME_UNITS_DAYS) {
+        param_set->force_steps_per_day[file_num] =
+            (size_t) (1. / (nc_times[1] - nc_times[0]));
+    }
+    else if (time_units == TIME_UNITS_HOURS) {
+        param_set->force_steps_per_day[file_num] =
+            (size_t) HOURS_PER_DAY / (nc_times[1] - nc_times[0]);
+    }
+    else if (time_units == TIME_UNITS_MINUTES) {
+        param_set->force_steps_per_day[file_num] =
+            (size_t) MIN_PER_DAY / (nc_times[1] - nc_times[0]);
+    }
+    else if (time_units == TIME_UNITS_SECONDS) {
+        param_set->force_steps_per_day[file_num] =
+            (size_t) SEC_PER_DAY / (nc_times[1] - nc_times[0]);
+    }
+
+    // check that this forcing file will work
+    if (param_set->force_steps_per_day[file_num] !=
+        global_param.model_steps_per_day) {
+        log_err("Forcing file timestep must match the model timestep.  "
+                "Model timesteps per day is set to %zu and the forcing file "
+                "timestep is set to %zu", global_param.model_steps_per_day,
+                param_set->force_steps_per_day[file_num])
+    }
+    if (calendar != global_param.calendar) {
+        log_err("Calendar in forcing file does not match the calendar of "
+                "VIC's clock: %s", calendar_char);
+    }
+}

--- a/vic/drivers/image/src/vic_init.c
+++ b/vic/drivers/image/src/vic_init.c
@@ -280,6 +280,29 @@ vic_init(void)
 
     // read_soilparam()
 
+    // Nlayer
+    options.Nlayer = get_nc_dimension(filenames.soil, "nlayer");
+
+    // Validate Nlayer
+    if ((options.FULL_ENERGY ||
+         options.FROZEN_SOIL) && options.Nlayer < 3) {
+        log_err("You must define at least 3 soil moisture layers to run "
+                "the model in FULL_ENERGY or FROZEN_SOIL modes.  "
+                "Currently Nlayers is set to  %zu.", options.Nlayer);
+    }
+    if ((!options.FULL_ENERGY &&
+         !options.FROZEN_SOIL) && options.Nlayer < 1) {
+        log_err("You must define at least 1 soil moisture layer to run "
+                "the model.  Currently Nlayers is set to %zu.",
+                options.Nlayer);
+    }
+    if (options.Nlayer > MAX_LAYERS) {
+        log_err("Global file wants more soil moisture layers (%zu) than "
+                "are defined by MAX_LAYERS (%d).  Edit vic_driver_shared.h and "
+                "recompile.", options.Nlayer, MAX_LAYERS);
+    }
+
+
     // b_infilt
     get_scatter_nc_field_double(filenames.soil, "infilt",
                                 d2start, d2count, dvar);

--- a/vic/drivers/python/vic_headers.py
+++ b/vic/drivers/python/vic_headers.py
@@ -1022,6 +1022,7 @@ double calc_veg_displacement(double);
 double calc_veg_height(double);
 double calc_veg_roughness(double);
 double calc_water_balance_error(int, double, double, double);
+unsigned short int calendar_from_chars(char *cal_chars);
 int CalcAerodynamic(_Bool, double, double, double, double, double, double *,
                     double *, double *, double *, double *);
 double CalcBlowingSnow(double, double, unsigned int, double, double, double,
@@ -1312,6 +1313,8 @@ void num2date(double origin, double time_value, double tzoffset,
               unsigned short int calendar, unsigned short int time_units,
               dmy_struct *date);
 FILE *open_file(char string[], char type[]);
+void parse_nc_time_units(char *nc_unit_chars, unsigned short int *units,
+                         dmy_struct *dmy);
 void print_cell_data(cell_data_struct *cell, size_t nlayers, size_t nfrost);
 void print_dmy(dmy_struct *dmy);
 void print_energy_bal(energy_bal_struct *eb, size_t nnodes, size_t nfronts);
@@ -1342,6 +1345,7 @@ void print_usage(char *);
 int set_output_var(out_data_file_struct *, int, int, out_data_struct *, char *,
                    int, char *, int, double);
 void soil_moisture_from_water_table(soil_con_struct *soil_con, size_t nlayers);
+unsigned short int timeunits_from_chars(char *units_chars);
 int update_step_vars(all_vars_struct *, veg_con_struct *, veg_hist_struct *);
 int valid_date(unsigned short int calendar, dmy_struct *dmy);
 void validate_parameters(void);

--- a/vic/drivers/shared/include/vic_driver_shared.h
+++ b/vic/drivers/shared/include/vic_driver_shared.h
@@ -438,6 +438,7 @@ double average(double *ar, size_t n);
 double calc_energy_balance_error(int, double, double, double, double, double);
 void calc_root_fractions(veg_con_struct *veg_con, soil_con_struct *soil_con);
 double calc_water_balance_error(int, double, double, double);
+unsigned short int calendar_from_chars(char *cal_chars);
 void collect_eb_terms(energy_bal_struct, snow_data_struct, cell_data_struct,
                       int *, int *, int *, int *, int *, double, double, double,
                       int, int, double, int, int, double *, double,
@@ -496,6 +497,8 @@ void num2date(double origin, double time_value, double tzoffset,
               unsigned short int calendar, unsigned short int time_units,
               dmy_struct *date);
 FILE *open_file(char string[], char type[]);
+void parse_nc_time_units(char *nc_unit_chars, unsigned short int *units,
+                         dmy_struct *dmy);
 int put_data(all_vars_struct *, atmos_data_struct *, soil_con_struct *,
              veg_con_struct *, veg_lib_struct *veg_lib, lake_con_struct *,
              out_data_struct *, save_data_struct *, int);
@@ -530,6 +533,7 @@ double q_to_vp(double q, double p);
 int set_output_var(out_data_file_struct *, int, int, out_data_struct *, char *,
                    int, char *, int, double);
 void soil_moisture_from_water_table(soil_con_struct *soil_con, size_t nlayers);
+unsigned short int timeunits_from_chars(char *units_chars);
 int update_step_vars(all_vars_struct *, veg_con_struct *, veg_hist_struct *);
 int valid_date(unsigned short int calendar, dmy_struct *dmy);
 void validate_parameters(void);

--- a/vic/drivers/shared/src/vic_time.c
+++ b/vic/drivers/shared/src/vic_time.c
@@ -776,3 +776,97 @@ dt_seconds_to_time_units(unsigned short int time_units,
         log_err("Unknown Time Units Flag: %hu", time_units);
     }
 }
+
+/******************************************************************************
+ * @brief  Parse chars of calendar and return calendar integer
+ * @return enum integer representing calendar
+ *****************************************************************************/
+unsigned short int
+calendar_from_chars(char *cal_chars)
+{
+    if (strcasecmp("STANDARD", cal_chars) == 0) {
+        return CALENDAR_STANDARD;
+    }
+    else if (strcasecmp("GREGORIAN", cal_chars) == 0) {
+        return CALENDAR_GREGORIAN;
+    }
+    else if (strcasecmp("PROLEPTIC_GREGORIAN", cal_chars) == 0) {
+        return CALENDAR_PROLEPTIC_GREGORIAN;
+    }
+    else if (strcasecmp("NOLEAP", cal_chars) == 0) {
+        return CALENDAR_NOLEAP;
+    }
+    else if (strcasecmp("365_DAY", cal_chars) == 0) {
+        return CALENDAR_365_DAY;
+    }
+    else if (strcasecmp("360_DAY", cal_chars) == 0) {
+        return CALENDAR_360_DAY;
+    }
+    else if (strcasecmp("JULIAN", cal_chars) == 0) {
+        return CALENDAR_JULIAN;
+    }
+    else if (strcasecmp("ALL_LEAP", cal_chars) == 0) {
+        return CALENDAR_ALL_LEAP;
+    }
+    else if (strcasecmp("366_DAY", cal_chars) == 0) {
+        return CALENDAR_366_DAY;
+    }
+    else {
+        log_err("Unknown calendar specified: %s", cal_chars);
+    }
+}
+
+/******************************************************************************
+ * @brief  Parse chars of time units and return time units integer
+ * @return enum integer representing time units
+ *****************************************************************************/
+unsigned short int
+timeunits_from_chars(char *units_chars)
+{
+    if (strcasecmp("SECONDS", units_chars) == 0) {
+        return TIME_UNITS_SECONDS;
+    }
+    else if (strcasecmp("MINUTES", units_chars) == 0) {
+        return TIME_UNITS_MINUTES;
+    }
+    else if (strcasecmp("HOURS", units_chars) == 0) {
+        return TIME_UNITS_HOURS;
+    }
+    else if (strcasecmp("DAYS", units_chars) == 0) {
+        return TIME_UNITS_DAYS;
+    }
+    else {
+        log_err("Unknown time units specified: %s", units_chars);
+    }
+}
+
+/******************************************************************************
+ * @brief  Parse units string in format of "<units> since <origin (YYYY-MM-DD)>"
+ *****************************************************************************/
+void
+parse_nc_time_units(char               *nc_unit_chars,
+                    unsigned short int *units,
+                    dmy_struct         *dmy)
+{
+    int  status;
+    char unit_chars[MAXSTRING];
+    int  hours = 0;
+    int  minutes = 0;
+    int  seconds = 0;
+
+    // Format: time:units = "seconds since 1970-1-1";
+    status = sscanf(nc_unit_chars, "%s since %d-%hu-%hu %d:%d:%d",
+                    unit_chars, &dmy->year, &dmy->month, &dmy->day,
+                    &hours, &minutes, &seconds);
+
+    if (status < 4) {
+        log_err("Unable to parse netcdf time units as specified: %s",
+                nc_unit_chars);
+    }
+
+    // dayseconds, this will be zero when the last part of the format
+    // string is not present
+    dmy->dayseconds = hours * SEC_PER_HOUR + minutes * SEC_PER_MIN + seconds;
+
+    *units = timeunits_from_chars(unit_chars);
+}

--- a/vic/drivers/shared/src/vic_time.c
+++ b/vic/drivers/shared/src/vic_time.c
@@ -854,7 +854,8 @@ parse_nc_time_units(char               *nc_unit_chars,
     int  minutes = 0;
     int  seconds = 0;
 
-    // Format: time:units = "seconds since 1970-1-1";
+    // Parse standard netCDF time units string. Note that sscanf return the
+    // number of variables parsed and that not all variables will be parsed
     status = sscanf(nc_unit_chars, "%s since %d-%hu-%hu %d:%d:%d",
                     unit_chars, &dmy->year, &dmy->month, &dmy->day,
                     &hours, &minutes, &seconds);


### PR DESCRIPTION
This PR cleans up the image driver global parameter file and deprecates invalid or unnecessary options. A follow up PR will have to add functionality to the selection of forcing files.

TODO:
- [x] unit tests for new functions added to `vic_time`

closes #373 