### PR TITLE
specify netcdf variable names in global parameter file

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -76,16 +76,16 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 
 	Computation of potential evapotranspiration (PET) has been simplified, reducing the number of output variables from 6 to 1.  The following output variables have been removed:
 
-        - 'OUT_PET_SATSOIL' (potential evap from saturated bare soil)
-        - 'OUT_PET_H2OSURF' (potential evap from open water)
-        - 'OUT_PET_SHORT' (potential evap (transpiration only) from short reference crop (grass))
-        - 'OUT_PET_TALL' (potential evap (transpiration only) from tall reference crop (alfalfa))
-        - 'OUT_PET_NATVEG' (potential evap (transpiration only) from current vegetation and current canopy resistance)
-        - 'OUT_PET_VEGNOCR' (potential evap (transpiration only) from current vegetation and 0 canopy resistance)
+    - `OUT_PET_SATSOIL` (potential evap from saturated bare soil)
+    - `OUT_PET_H2OSURF` (potential evap from open water)
+    - `OUT_PET_SHORT` (potential evap (transpiration only) from short reference crop (grass))
+    - `OUT_PET_TALL` (potential evap (transpiration only) from tall reference crop (alfalfa))
+    - `OUT_PET_NATVEG` (potential evap (transpiration only) from current vegetation and current canopy resistance)
+    - `OUT_PET_VEGNOCR` (potential evap (transpiration only) from current vegetation and 0 canopy resistance)
 
-        These have been replaced by:
+    These have been replaced by:
 
-        - 'OUT_PET' (potential evapotranspiration, which = area-weighted sum of potential transpiration and potential soil evaporation; potential transpiration is computed using the Penman-Monteith eqn with architectural resistance and LAI of the current veg cover)
+    - `OUT_PET` (potential evapotranspiration, which = area-weighted sum of potential transpiration and potential soil evaporation; potential transpiration is computed using the Penman-Monteith eqn with architectural resistance and LAI of the current veg cover)
 
 #### Deprecated Features:
 
@@ -102,6 +102,11 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 	- `OUTPUT_FORCE`
 
 	We are providing a stand-alone version of MTCLIM that produces subdaily VIC meteorological forcings.  That tool is available [here](http://mtclim.readthedocs.org).
+3. Removed `LONGWAVE` and `SHORTWAVE` forcing types ([GH#379](https://github.com/UW-Hydro/VIC/pull/379)).
+
+	Previous versions of VIC allowed users to specify either `LONGWAVE` or `LWDOWN` to denote the incoming longwave radiation flux and `SHORTWAVE` or `SWDOWN` to denote the incoming shorwave radiation flux. We have removed these duplicate options, standardizing on the more descriptive `LWDOWN` and `SWDOWN`.
+
+	Similarly, output variables `OUT_NET_LONG` and `OUT_NET_SHORT` have been replaced with `OUT_LWNET` and `OUT_SWNET`, respectively.
 
 3.  Changed the name of the variable VEGCOVER to FCANOPY, since this more accurately captures the meaning of the term (i.e., the fractional area of the plant canopy within the veg tile).  Similarly changed OUT_VEGCOVER to OUT_FCANOPY.
 

--- a/docs/Documentation/Drivers/Classic/ForcingData.md
+++ b/docs/Documentation/Drivers/Classic/ForcingData.md
@@ -9,8 +9,8 @@ The VIC Classic Driver requires subdaily forcings (meteorological or other).  Th
 | AIR_TEMP   | Average air temperature             | C               |
 | PREC       | Total precipitation (rain and snow) | mm              |
 | PRESSURE   | Atmospheric pressure                | kPa             |
-| SHORTWAVE  | Incoming shortwave                  | W/m<sup>2</sup> |
-| LONGWAVE   | Incoming longwave radiation         | W/m<sup>2</sup> |
+| SWDOWN     | Incoming shortwave radiation        | W/m<sup>2</sup> |
+| LWDOWN     | Incoming longwave radiation         | W/m<sup>2</sup> |
 | VP         | Vapor pressure                      | kPa             |
 | WIND       | Wind speed                          | m/s             |
 

--- a/docs/Documentation/OutputVarList.md
+++ b/docs/Documentation/OutputVarList.md
@@ -118,8 +118,8 @@ Using options within the *global parameter file*, any combination of the variabl
 | OUT_LATENT       	| Net upward latent heat flux                          	| W/m<sup>2</sup>                     	|
 | OUT_LATENT_SUB   	| Net upward latent heat flux from sublimation         	| W/m<sup>2</sup>                     	|
 | OUT_MELT_ENERGY  	| Energy of fusion (melting) in snowpack               	| W/m<sup>2</sup>                     	|
-| OUT_NET_LONG     	| Net downward longwave flux                           	| W/m<sup>2</sup>                     	|
-| OUT_NET_SHORT    	| Net downward shortwave flux                          	| W/m<sup>2</sup>                     	|
+| OUT_LWNET     	| Net downward longwave flux                           	| W/m<sup>2</sup>                     	|
+| OUT_SWNET    	| Net downward shortwave flux                          	| W/m<sup>2</sup>                     	|
 | OUT_R_NET        	| Net downward radiation flux                          	| W/m<sup>2</sup>                     	|
 | OUT_RFRZ_ENERGY  	| Net energy used to refreeze liquid water in snowpack 	| W/m<sup>2</sup>                     	|
 | OUT_SENSIBLE     	| Net upward sensible heat flux                        	| W/m<sup>2</sup>                     	|
@@ -138,11 +138,11 @@ Using options within the *global parameter file*, any combination of the variabl
 | OUT_FCANOPY     	| Vegetation canopy cover fraction                                                                                                	| fraction              	|
 | OUT_FDIR         	| fraction of incoming shortwave that is direct                                                                                    	| fraction              	|
 | OUT_LAI          	| Leaf Area Index                                                                                                                  	| fraction              	|
-| OUT_LONGWAVE     	| Incoming longwave                                                                                                                	| W/m<sup>2</sup>                  	|
+| OUT_LWDOWN     	| Incoming longwave                                                                                                                	| W/m<sup>2</sup>                  	|
 | OUT_PRESSURE     	| Near surface atmospheric pressure                                                                                                	| kPa (ALMA_OUTPUT: Pa) 	|
 | OUT_QAIR         	| Specific humidity                                                                                                                	| kg/kg                 	|
 | OUT_REL_HUMID    	| Relative humidity                                                                                                                	| fraction              	|
-| OUT_SHORTWAVE    	| Incoming shortwave                                                                                                               	| W/m<sup>2</sup>                  	|
+| OUT_SWDOWN    	| Incoming shortwave                                                                                                               	| W/m<sup>2</sup>                  	|
 | OUT_SURF_COND    	| Surface conductance                                                                                                              	| m/s                   	|
 | OUT_TSKC         	| (release 4.1.2 and later)  Cloud fraction                                                                                       	| fraction              	|
 | OUT_VP           	| Near surface vapor pressure                                                                                                      	| kPa (ALMA_OUTPUT: Pa) 	|
@@ -161,8 +161,8 @@ Using options within the *global parameter file*, any combination of the variabl
 | OUT_LATENT_BAND      	| Net upward latent heat flux                          	| W/m<sup>2</sup>               	|
 | OUT_LATENT_SUB_BAND  	| Net upward latent heat flux due to sublimation       	| W/m<sup>2</sup>               	|
 | OUT_MELT_ENERGY_BAND 	| Energy of fusion (melting) in snowpack               	| W/m<sup>2</sup>               	|
-| OUT_NET_LONG_BAND    	| Net downward longwave flux                           	| W/m<sup>2</sup>               	|
-| OUT_NET_SHORT_BAND   	| Net downward shortwave flux                          	| W/m<sup>2</sup>               	|
+| OUT_LWNET_BAND    	| Net downward longwave flux                           	| W/m<sup>2</sup>               	|
+| OUT_SWNET_BAND   	| Net downward shortwave flux                          	| W/m<sup>2</sup>               	|
 | OUT_RFRZ_ENERGY_BAND 	| Net energy used to refreeze liquid water in snowpack 	| W/m<sup>2</sup>               	|
 | OUT_SENSIBLE_BAND    	| Net upward sensible heat flux                        	| W/m<sup>2</sup>               	|
 | OUT_SNOW_CANOPY_BAND 	| Snow interception storage in canopy                  	| mm                 	|

--- a/samples/global.param.sample.image.txt
+++ b/samples/global.param.sample.image.txt
@@ -19,6 +19,18 @@ ENDDAY		31	# day model simulation ends
 # LOG_DIR (put the log directory path here)    # Log directory.  Default log output to stderr
 
 #######################################################################
+# DOMAIN INFO
+#######################################################################
+DOMAIN /Users/jhamman/Dropbox/data/VIC_test_data/datasets/Stehekin/vic5_setup/domain.stehekin.20151028.nc
+DOMAIN_TYPE    LAT     lat
+DOMAIN_TYPE    LON     lon
+DOMAIN_TYPE    MASK    mask
+DOMAIN_TYPE    AREA    area
+DOMAIN_TYPE    FRAC    frac
+DOMAIN_TYPE    YDIM    lat
+DOMAIN_TYPE    XDIM    lon
+
+#######################################################################
 # Simulation Parameters Namelist
 #######################################################################
 # CONSTANTS     (put the parameter namelist path here) # Update default model paramters.  Format is "PARAM VAL".
@@ -105,32 +117,22 @@ FROZEN_SOIL	FALSE	# TRUE = calculate frozen soils.  Default = FALSE.
 #######################################################################
 # Forcing Files and Parameters
 #
-#       All FORCING filenames are actually the pathname, and prefix
-#               for gridded data types: ex. DATA/forcing_
-#               Latitude and longitude index suffix is added by VIC
+#    All FORCING filenames are actually the pathname, and prefix
 #
-#	There must be 1 FORCE_TYPE entry for each variable (column) in the forcing file
+#    There must be 1 FORCE_TYPE entry for each variable in the forcing file, followed by the netCDF variable name.  For example:
 #
-#	If FORCE_TYPE is BINARY, each FORCE_TYPE must be followed by:
-#			SIGNED/UNSIGNED	SCALE_FACTOR
-#		For example (BINARY):
-#			FORCE_TYPE	PREC	UNSIGNED	40
-#		or (ASCII):
-#			FORCE_TYPE	PREC
+#    FORCING1	(put the forcing path/prefix here)	# Forcing file path and prefix, ending in "_"
+#    FORCE_TYPE	PREC         prcp
 #######################################################################
-FORCING1	(put the forcing path/prefix here)	# Forcing file path and prefix, ending in "_"
-FORCE_FORMAT	BINARY	# BINARY or ASCII
-FORCE_ENDIAN	LITTLE	# LITTLE (PC/Linux) or BIG (SUN)
-FORCE_TYPE	PREC	UNSIGNED	40
-FORCE_TYPE	TMAX	SIGNED	100
-FORCE_TYPE	TMIN	SIGNED	100
-FORCE_TYPE	WIND	SIGNED	100
-FORCE_STEPS_PER_DAY	24	# Forcing time step length (hours)
-FORCEYEAR	2000	# Year of first forcing record
-FORCEMONTH	01	# Month of first forcing record
-FORCEDAY	01	# Day of first forcing record
-GRID_DECIMAL	4	# Number of digits after decimal point in forcing file names
-WIND_H          10.0    # height of wind speed measurement (m)
+FORCING1      (put the forcing path/prefix here  # Forcing file path and prefix, ending in "_"
+FORCE_TYPE    AIR_TEMP 	   tas    # Average air temperature, C
+FORCE_TYPE    PREC 	   prcp   # Total precipitation (rain and snow), mm
+FORCE_TYPE    PRESSURE 	   pres   # Atmospheric pressure, kPa
+FORCE_TYPE    SHORTWAVE    dswrf  # Incoming shortwave, W/m2
+FORCE_TYPE    LONGWAVE 	   dslwr  # Incoming longwave radiation, W/m2
+FORCE_TYPE    QAIR 	   shum   # Vapor pressure, kPa
+FORCE_TYPE    WIND 	   wind   # Wind speed, m/s
+WIND_H        10.0                # height of wind speed measurement (m)
 
 #######################################################################
 # Land Surface Files and Parameters

--- a/vic/drivers/classic/include/vic_driver_classic.h
+++ b/vic/drivers/classic/include/vic_driver_classic.h
@@ -41,7 +41,6 @@ double calc_netshort(double, int, double, double *);
 void check_files(filep_struct *, filenames_struct *);
 FILE  *check_state_file(char *, size_t, size_t, int *);
 void close_files(filep_struct *, out_data_file_struct *, filenames_struct *);
-size_t count_force_vars(FILE *gp);
 size_t count_n_outfiles(FILE *gp);
 void compute_cell_area(soil_con_struct *);
 size_t count_outfile_nvars(FILE *gp);

--- a/vic/drivers/classic/src/parse_output_info.c
+++ b/vic/drivers/classic/src/parse_output_info.c
@@ -86,18 +86,21 @@ parse_output_info(FILE                  *gp,
                                 "%zu but found %hu", options.Noutfiles,
                                 outfilenum);
                     }
-                    sscanf(cmdstr, "%*s %s", (*out_data_files)[outfilenum].prefix);
+                    sscanf(cmdstr, "%*s %s",
+                           (*out_data_files)[outfilenum].prefix);
 
                     // determine how many variable will be in this file before
                     // allocating (GH: 209)
-                    (*out_data_files)[outfilenum].nvars = count_outfile_nvars(gp);
+                    (*out_data_files)[outfilenum].nvars =
+                        count_outfile_nvars(gp);
 
                     (*out_data_files)[outfilenum].varid =
                         calloc((*out_data_files)[outfilenum].nvars,
                                sizeof(*((*out_data_files)[outfilenum].varid)));
-                   if ((*out_data_files)[outfilenum].varid == NULL) {
-                       log_err("Memory allocation error in parse_output_info().");
-                   }
+                    if ((*out_data_files)[outfilenum].varid == NULL) {
+                        log_err(
+                            "Memory allocation error in parse_output_info().");
+                    }
                     outvarnum = 0;
                 }
                 else if (strcasecmp("OUTVAR", optstr) == 0) {
@@ -139,7 +142,8 @@ parse_output_info(FILE                  *gp,
                         }
                     }
                     if (set_output_var((*out_data_files), true, outfilenum,
-                                       out_data, varname, outvarnum, format, type,
+                                       out_data, varname, outvarnum, format,
+                                       type,
                                        mult) != 0) {
                         log_err("Invalid output variable specification.");
                     }
@@ -152,7 +156,6 @@ parse_output_info(FILE                  *gp,
     }
     fclose(gp);
 }
-
 
 /******************************************************************************
  * @brief    This routine determines the counts the number of output variables
@@ -198,7 +201,6 @@ count_outfile_nvars(FILE *gp)
 
     return nvars;
 }
-
 
 /******************************************************************************
  * @brief    This routine determines the counts the number of output files

--- a/vic/drivers/classic/src/set_output_defaults.c
+++ b/vic/drivers/classic/src/set_output_defaults.c
@@ -117,7 +117,7 @@ set_output_defaults(out_data_struct *out_data)
         set_output_var(out_data_files, true, filenum, out_data,
                        "OUT_RAD_TEMP", varnum++, "%.4f", OUT_TYPE_FLOAT, 1);
     }
-    set_output_var(out_data_files, true, filenum, out_data, "OUT_NET_SHORT",
+    set_output_var(out_data_files, true, filenum, out_data, "OUT_SWNET",
                    varnum++, "%.4f", OUT_TYPE_FLOAT, 1);
     set_output_var(out_data_files, true, filenum, out_data, "OUT_R_NET",
                    varnum++, "%.4f", OUT_TYPE_FLOAT, 1);
@@ -254,10 +254,10 @@ set_output_defaults(out_data_struct *out_data)
                            OUT_TYPE_FLOAT, 1);
         }
         set_output_var(out_data_files, true, filenum, out_data,
-                       "OUT_NET_SHORT_BAND", varnum++, "%.4f",
+                       "OUT_SWNET_BAND", varnum++, "%.4f",
                        OUT_TYPE_FLOAT, 1);
         set_output_var(out_data_files, true, filenum, out_data,
-                       "OUT_NET_LONG_BAND", varnum++, "%.4f",
+                       "OUT_LWNET_BAND", varnum++, "%.4f",
                        OUT_TYPE_FLOAT, 1);
         set_output_var(out_data_files, true, filenum, out_data,
                        "OUT_ALBEDO_BAND", varnum++, "%.4f", OUT_TYPE_FLOAT,

--- a/vic/drivers/classic/src/vic_force.c
+++ b/vic/drivers/classic/src/vic_force.c
@@ -68,10 +68,10 @@ vic_force(atmos_data_struct *atmos,
     if (!param_set.TYPE[PREC].SUPPLIED) {
         log_err("Precipitation must be supplied as a forcing");
     }
-    if (!param_set.TYPE[SHORTWAVE].SUPPLIED) {
+    if (!param_set.TYPE[SWDOWN].SUPPLIED) {
         log_err("Downward shortwave radiation must be supplied as a forcing");
     }
-    if (!param_set.TYPE[LONGWAVE].SUPPLIED) {
+    if (!param_set.TYPE[LWDOWN].SUPPLIED) {
         log_err("Downward longwave radiation must be supplied as a forcing");
     }
     if (!param_set.TYPE[PRESSURE].SUPPLIED) {
@@ -131,9 +131,9 @@ vic_force(atmos_data_struct *atmos,
             // precipitation in mm/period
             atmos[rec].prec[i] = forcing_data[PREC][uidx];
             // downward shortwave in W/m2
-            atmos[rec].shortwave[i] = forcing_data[SHORTWAVE][uidx];
+            atmos[rec].shortwave[i] = forcing_data[SWDOWN][uidx];
             // downward longwave in W/m2
-            atmos[rec].longwave[i] = forcing_data[LONGWAVE][uidx];
+            atmos[rec].longwave[i] = forcing_data[LWDOWN][uidx];
             // pressure in kPa
             atmos[rec].pressure[i] = forcing_data[PRESSURE][uidx] * PA_PER_KPA;
             // vapor pressure in kPa

--- a/vic/drivers/classic/src/write_forcing_file.c
+++ b/vic/drivers/classic/src/write_forcing_file.c
@@ -54,7 +54,7 @@ write_forcing_file(atmos_data_struct    *atmos,
         for (j = 0; j < NF; j++) {
             out_data[OUT_AIR_TEMP].data[0] = atmos[rec].air_temp[j];
             out_data[OUT_DENSITY].data[0] = atmos[rec].density[j];
-            out_data[OUT_LONGWAVE].data[0] = atmos[rec].longwave[j];
+            out_data[OUT_LWDOWN].data[0] = atmos[rec].longwave[j];
             out_data[OUT_PREC].data[0] = atmos[rec].prec[j];
             out_data[OUT_PRESSURE].data[0] = atmos[rec].pressure[j] /
                                              PA_PER_KPA;
@@ -64,7 +64,7 @@ write_forcing_file(atmos_data_struct    *atmos,
                                               atmos[rec].vp[j] /
                                               (atmos[rec].vp[j] +
                                                atmos[rec].vpd[j]);
-            out_data[OUT_SHORTWAVE].data[0] = atmos[rec].shortwave[j];
+            out_data[OUT_SWDOWN].data[0] = atmos[rec].shortwave[j];
             out_data[OUT_VP].data[0] = atmos[rec].vp[j] / PA_PER_KPA;
             out_data[OUT_VPD].data[0] = atmos[rec].vpd[j] / PA_PER_KPA;
             out_data[OUT_WIND].data[0] = atmos[rec].wind[j];

--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -54,6 +54,19 @@ typedef struct {
     size_t local_idx; /**< index of grid cell in local list of grid cells */
 } location_struct;
 
+/******************************************************************************
+ * @brief    Structure to store information about the domain file.
+ *****************************************************************************/
+typedef struct {
+    char lat_var[MAXSTRING];
+    char lon_var[MAXSTRING];
+    char mask_var[MAXSTRING];
+    char area_var[MAXSTRING];
+    char frac_var[MAXSTRING];
+    char y_dim[MAXSTRING];
+    char x_dim[MAXSTRING];
+    size_t n_coord_dims;
+} domain_info_struct;
 
 /******************************************************************************
  * @brief    Structure to store local and global domain information. If the
@@ -65,6 +78,7 @@ typedef struct {
     size_t n_nx; /**< size of x-index; */
     size_t n_ny; /**< size of y-index */
     location_struct *locations; /**< locations structs for local domain */
+    domain_info_struct info; /**< structure storing domain file info */
 } domain_struct;
 
 /******************************************************************************
@@ -138,6 +152,7 @@ double average(double *ar, size_t n);
 out_data_struct *create_output_list(void);
 void free_atmos(atmos_data_struct *atmos);
 void free_veg_hist(veg_hist_struct *veg_hist);
+void get_domain_type(char *cmdstr);
 void get_forcing_file_info(param_set_struct *param_set, size_t file_num);
 size_t get_global_domain(char *fname, domain_struct *global_domain);
 void get_global_param(FILE *);
@@ -175,6 +190,7 @@ int put_nc_field_double(char *nc_name, bool *open, int *nc_id, double fillval,
 int put_nc_field_int(char *nc_name, bool *open, int *nc_id, int fillval,
                      int *dimids, int ndims, char *var_name, size_t *start,
                      size_t *count, int *var);
+void set_force_type(char *cmdstr, int file_num, int *field);
 void sprint_location(char *str, location_struct *loc);
 void vic_alloc(void);
 void vic_nc_info(nc_file_struct *nc_hist_file, out_data_struct **out_data,

--- a/vic/drivers/image/src/get_global_param.c
+++ b/vic/drivers/image/src/get_global_param.c
@@ -47,6 +47,7 @@ get_global_param(FILE *gp)
     char                       flgstr[MAXSTRING];
     char                       flgstr2[MAXSTRING];
     size_t                     file_num;
+    int                        field;
     unsigned int               tmpstartdate;
     unsigned int               tmpenddate;
     unsigned short int         lastday[MONTHS_PER_YEAR];
@@ -401,6 +402,9 @@ get_global_param(FILE *gp)
                 }
                 sscanf(cmdstr, "%*s %s", filenames.f_path_pfx[0]);
                 file_num = 0;
+                field = 0;
+                // count the number of forcing variables in this file
+                param_set.N_TYPES[file_num] = count_force_vars(gp);
             }
             else if (strcasecmp("FORCING2", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", filenames.f_path_pfx[1]);
@@ -408,6 +412,12 @@ get_global_param(FILE *gp)
                     strcpy(filenames.f_path_pfx[1], "MISSING");
                 }
                 file_num = 1;
+                field = 0;
+                // count the number of forcing variables in this file
+                param_set.N_TYPES[file_num] = count_force_vars(gp);
+            }
+            else if (strcasecmp("FORCE_TYPE", optstr) == 0) {
+                set_force_type(cmdstr, file_num, &field);
             }
             else if (strcasecmp("WIND_H", optstr) == 0) {
                 sscanf(cmdstr, "%*s %lf", &global_param.wind_h);
@@ -421,6 +431,9 @@ get_global_param(FILE *gp)
             }
             else if (strcasecmp("DOMAIN", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", filenames.domain);
+            }
+            else if (strcasecmp("DOMAIN_TYPE", optstr) == 0) {
+                get_domain_type(cmdstr);
             }
             else if (strcasecmp("SOIL", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", filenames.soil);
@@ -587,12 +600,6 @@ get_global_param(FILE *gp)
             }
             else if (strcasecmp("SKIPYEAR", optstr) == 0) {
                 sscanf(cmdstr, "%*s %hu", &global_param.skipyear);
-            }
-            else if (strcasecmp("DOMAIN_LON_VAR", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", options.DOMAIN_LON_VAR);
-            }
-            else if (strcasecmp("DOMAIN_LAT_VAR", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", options.DOMAIN_LAT_VAR);
             }
             else if (strcasecmp("ALMA_OUTPUT", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);

--- a/vic/drivers/image/src/get_nc_var_attr.c
+++ b/vic/drivers/image/src/get_nc_var_attr.c
@@ -32,9 +32,9 @@
  * @brief    Get netCDF dimension.
  *****************************************************************************/
 void
-get_nc_var_attr(char *nc_name,
-                char *var_name,
-                char *attr_name,
+get_nc_var_attr(char  *nc_name,
+                char  *var_name,
+                char  *attr_name,
                 char **attr)
 {
     int    nc_id;
@@ -57,7 +57,8 @@ get_nc_var_attr(char *nc_name,
     // get size of the attribute
     status = nc_inq_attlen(nc_id, var_id, attr_name, &attr_len);
     if (status != NC_NOERR) {
-        log_err("Error getting attribute length for %s:%s in %s", var_name, attr_name, nc_name);
+        log_err("Error getting attribute length for %s:%s in %s", var_name,
+                attr_name, nc_name);
     }
 
     // allocate memory for attribute

--- a/vic/drivers/image/src/set_force_type.c
+++ b/vic/drivers/image/src/set_force_type.c
@@ -27,14 +27,14 @@
 
 #include <vic_def.h>
 #include <vic_run.h>
-#include <vic_driver_classic.h>
+#include <vic_driver_image.h>
 
 /******************************************************************************
  * @brief    This routine determines the current forcing file data type and
  *           stores its location in the description of the current forcing file.
  *****************************************************************************/
 void
-get_force_type(char *cmdstr,
+set_force_type(char *cmdstr,
                int   file_num,
                int  *field)
 {
@@ -42,18 +42,21 @@ get_force_type(char *cmdstr,
 
     char                    optstr[MAXSTRING];
     char                    flgstr[MAXSTRING];
-    int                     type;
+    char                    ncvarname[MAXSTRING];
+    int                     type = SKIP;
 
-    type = SKIP;
+    strcpy(ncvarname, "MISSING");
 
     /** Initialize flgstr **/
     strcpy(flgstr, "NULL");
 
     if ((*field) >= (int) param_set.N_TYPES[file_num]) {
-        log_err("Too many variables defined for forcing file %i.", file_num);
+        log_err("Too many variables defined for forcing file %i., was "
+                "expecting at most %zu and got %d", file_num + 1,
+                param_set.N_TYPES[file_num], *field);
     }
 
-    sscanf(cmdstr, "%*s %s", optstr);
+    sscanf(cmdstr, "%*s %s %s", optstr, ncvarname);
 
     /***************************************
        Get meteorological data forcing info
@@ -75,76 +78,68 @@ get_force_type(char *cmdstr,
     else if (strcasecmp("CHANNEL_IN", optstr) == 0) {
         type = CHANNEL_IN;
     }
-    /* type 4: vegetation canopy cover fraction */
-    else if (strcasecmp("FCANOPY", optstr) == 0) {
-        type = FCANOPY;
-    }
-    /* type 5: direct fraction of shortwave [fraction] */
+    /* type 4: direct fraction of shortwave [fraction] */
     else if (strcasecmp("FDIR", optstr) == 0) {
         type = FDIR;
     }
-    /* type 6: LAI [m2/m2] */
+    /* type 5: LAI [m2/m2] */
     else if (strcasecmp("LAI_IN", optstr) == 0) {
         type = LAI_IN;
     }
-    /* type 7: incoming longwave radiation [W/m2] */
+    /* type 6: incoming longwave radiation [W/m2] */
     else if (strcasecmp("LWDOWN", optstr) == 0) {
         type = LWDOWN;
     }
-    /* type 8: photosynthetically active radiation [uE/m2s] */
+    /* type 7: photosynthetically active radiation [uE/m2s] */
     else if (strcasecmp("PAR", optstr) == 0) {
         type = PAR;
     }
-    /* type 9: precipitation [mm] */
+    /* type 8: precipitation [mm] */
     else if (strcasecmp("PREC", optstr) == 0) {
         type = PREC;
     }
-    /* type 10: air pressure [kPa] */
+    /* type 9: air pressure [kPa] */
     else if (strcasecmp("PRESSURE", optstr) == 0) {
         type = PRESSURE;
     }
-    /* type 11: vapor pressure [kPa] */
+    /* type 10: vapor pressure [kPa] */
     else if (strcasecmp("VP", optstr) == 0) {
         type = VP;
     }
-    /* type 12: incoming shortwave radiation [W/m2]  */
+    /* type 11: incoming shortwave radiation [W/m2] */
     else if (strcasecmp("SWDOWN", optstr) == 0) {
         type = SWDOWN;
     }
-    /* type 13: vegetation cover fraction */
+    /* type 12: vegetation cover fraction */
     else if (strcasecmp("FCANOPY", optstr) == 0) {
         type = FCANOPY;
     }
-    /* type 14: wind speed [m/s] */
+    /* type 13: wind speed [m/s] */
     else if (strcasecmp("WIND", optstr) == 0) {
         type = WIND;
     }
-    /* type 15: unused (blank) data */
+    /* type 14: unused (blank) data */
     else if (strcasecmp("SKIP", optstr) == 0) {
         type = SKIP;
     }
     /** Undefined variable type **/
     else {
         log_err("Undefined forcing variable type %s in file %i.",
-                optstr, file_num);
+                optstr, file_num + 1);
     }
 
     param_set.TYPE[type].SUPPLIED = file_num + 1;
     param_set.FORCE_INDEX[file_num][(*field)] = type;
-    if (type == SKIP) {
-        param_set.TYPE[type].multiplier = 1;
-        param_set.TYPE[type].SIGNED = false;
+
+    if (strcasecmp("MISSING", ncvarname) != 0) {
+        strcpy(param_set.TYPE[type].varname, ncvarname);
     }
     else {
-        sscanf(cmdstr, "%*s %*s %s %lf", flgstr,
-               &param_set.TYPE[type].multiplier);
-        if (strcasecmp("SIGNED", flgstr) == 0) {
-            param_set.TYPE[type].SIGNED = true;
-        }
-        else {
-            param_set.TYPE[type].SIGNED = false;
-        }
+        log_err(
+            "Must supply netCDF variable name for %s forcing file number %d",
+            optstr, file_num + 1);
     }
+
     param_set.TYPE[type].N_ELEM = 1;
 
     (*field)++;

--- a/vic/drivers/image/src/vic_alloc.c
+++ b/vic/drivers/image/src/vic_alloc.c
@@ -209,6 +209,6 @@ vic_alloc(void)
         for (j = 0; j < veg_con_map[i].nv_active; j++) {
             alloc_veg_hist(&(veg_hist[i][j]));
         }
- 
+
     }
 }

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -48,6 +48,7 @@ vic_force(void)
     extern veg_con_struct    **veg_con;
     extern veg_hist_struct   **veg_hist;
     extern parameters_struct   param;
+    extern param_set_struct    param_set;
 
     double                     t_offset;
     double                    *dvar = NULL;
@@ -86,7 +87,8 @@ vic_force(void)
     // Air temperature: tas
     for (j = 0; j < NF; j++) {
         d3start[0] = global_param.forceoffset[0] + j;
-        get_scatter_nc_field_double(filenames.forcing[0], "tas",
+        get_scatter_nc_field_double(filenames.forcing[0],
+                                    param_set.TYPE[AIR_TEMP].varname,
                                     d3start, d3count, dvar);
         for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].air_temp[j] = (double) dvar[i];
@@ -96,7 +98,8 @@ vic_force(void)
     // Precipitation: prcp
     for (j = 0; j < NF; j++) {
         d3start[0] = global_param.forceoffset[0] + j;
-        get_scatter_nc_field_double(filenames.forcing[0], "prcp",
+        get_scatter_nc_field_double(filenames.forcing[0],
+                                    param_set.TYPE[PREC].varname,
                                     d3start, d3count, dvar);
         for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].prec[j] = (double) dvar[i];
@@ -106,7 +109,8 @@ vic_force(void)
     // Downward solar radiation: dswrf
     for (j = 0; j < NF; j++) {
         d3start[0] = global_param.forceoffset[0] + j;
-        get_scatter_nc_field_double(filenames.forcing[0], "dswrf",
+        get_scatter_nc_field_double(filenames.forcing[0],
+                                    param_set.TYPE[SWDOWN].varname,
                                     d3start, d3count, dvar);
         for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].shortwave[j] = (double) dvar[i];
@@ -116,7 +120,8 @@ vic_force(void)
     // Downward longwave radiation: dlwrf
     for (j = 0; j < NF; j++) {
         d3start[0] = global_param.forceoffset[0] + j;
-        get_scatter_nc_field_double(filenames.forcing[0], "dlwrf",
+        get_scatter_nc_field_double(filenames.forcing[0],
+                                    param_set.TYPE[LWDOWN].varname,
                                     d3start, d3count, dvar);
         for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].longwave[j] = (double) dvar[i];
@@ -136,7 +141,8 @@ vic_force(void)
     // Specific humidity: shum
     for (j = 0; j < NF; j++) {
         d3start[0] = global_param.forceoffset[0] + j;
-        get_scatter_nc_field_double(filenames.forcing[0], "shum",
+        get_scatter_nc_field_double(filenames.forcing[0],
+                                    param_set.TYPE[VP].varname,
                                     d3start, d3count, dvar);
         for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].vp[j] = (double) dvar[i];
@@ -146,7 +152,8 @@ vic_force(void)
     // Pressure: pressure
     for (j = 0; j < NF; j++) {
         d3start[0] = global_param.forceoffset[0] + j;
-        get_scatter_nc_field_double(filenames.forcing[0], "pres",
+        get_scatter_nc_field_double(filenames.forcing[0],
+                                    param_set.TYPE[PRESSURE].varname,
                                     d3start, d3count, dvar);
         for (i = 0; i < local_domain.ncells_active; i++) {
             atmos[i].pressure[j] = (double) dvar[i];
@@ -155,9 +162,13 @@ vic_force(void)
     // Optional inputs
     if (options.LAKES) {
         // Channel inflow to lake
+        d3start[0] = global_param.forceoffset[0] + j;
+        get_scatter_nc_field_double(filenames.forcing[0],
+                                    param_set.TYPE[CHANNEL_IN].varname,
+                                    d3start, d3count, dvar);
         for (j = 0; j < NF; j++) {
             for (i = 0; i < local_domain.ncells_active; i++) {
-                atmos[i].channel_in[j] = 0;
+                atmos[i].channel_in[j] = (double) dvar[i];
             }
         }
     }
@@ -165,7 +176,8 @@ vic_force(void)
         // Atmospheric CO2 mixing ratio
         for (j = 0; j < NF; j++) {
             d3start[0] = global_param.forceoffset[0] + j;
-            get_scatter_nc_field_double(filenames.forcing[0], "catm",
+            get_scatter_nc_field_double(filenames.forcing[0],
+                                        param_set.TYPE[CATM].varname,
                                         d3start, d3count, dvar);
             for (i = 0; i < local_domain.ncells_active; i++) {
                 atmos[i].Catm[j] = (double) dvar[i];
@@ -174,7 +186,8 @@ vic_force(void)
         // Fraction of shortwave that is direct
         for (j = 0; j < NF; j++) {
             d3start[0] = global_param.forceoffset[0] + j;
-            get_scatter_nc_field_double(filenames.forcing[0], "fdir",
+            get_scatter_nc_field_double(filenames.forcing[0],
+                                        param_set.TYPE[FDIR].varname,
                                         d3start, d3count, dvar);
             for (i = 0; i < local_domain.ncells_active; i++) {
                 atmos[i].fdir[j] = (double) dvar[i];
@@ -183,7 +196,8 @@ vic_force(void)
         // Photosynthetically active radiation
         for (j = 0; j < NF; j++) {
             d3start[0] = global_param.forceoffset[0] + j;
-            get_scatter_nc_field_double(filenames.forcing[0], "par",
+            get_scatter_nc_field_double(filenames.forcing[0],
+                                        param_set.TYPE[PAR].varname,
                                         d3start, d3count, dvar);
             for (i = 0; i < local_domain.ncells_active; i++) {
                 atmos[i].par[j] = (double) dvar[i];
@@ -463,5 +477,4 @@ get_forcing_file_info(param_set_struct *param_set,
     // Free attribute character arrays
     free(nc_unit_chars);
     free(calendar_char);
-
 }

--- a/vic/drivers/image/src/vic_init_output.c
+++ b/vic/drivers/image/src/vic_init_output.c
@@ -175,32 +175,17 @@ initialize_history_file(nc_file_struct *nc)
         log_err("Error defining nlayer dimenension in %s", nc->fname);
     }
 
-    if (options.COORD_DIMS_OUT == 1) {
-        status =
-            nc_def_dim(nc->nc_id, "lon", nc->ni_size,
-                       &(nc->ni_dimid));
-    }
-    else {
-        nc_def_dim(nc->nc_id, "ni", nc->ni_size,
-                   &(nc->ni_dimid));
-    }
+    status = nc_def_dim(nc->nc_id, global_domain.info.x_dim, nc->ni_size,
+                        &(nc->ni_dimid));
 
     if (status != NC_NOERR) {
-        log_err("Error defining ni dimenension in %s", nc->fname);
+        log_err("Error defining x dimenension in %s", nc->fname);
     }
+    status = nc_def_dim(nc->nc_id, global_domain.info.y_dim, nc->nj_size,
+                        &(nc->nj_dimid));
 
-    if (options.COORD_DIMS_OUT == 1) {
-        status =
-            nc_def_dim(nc->nc_id, "lat", nc->nj_size,
-                       &(nc->nj_dimid));
-    }
-    else {
-        status =
-            nc_def_dim(nc->nc_id, "nj", nc->nj_size,
-                       &(nc->nj_dimid));
-    }
     if (status != NC_NOERR) {
-        log_err("Error defining nj dimenension in %s", nc->fname);
+        log_err("Error defining y dimenension in %s", nc->fname);
     }
 
     status = nc_def_dim(nc->nc_id, "node", nc->node_size, &(nc->node_dimid));
@@ -301,15 +286,15 @@ initialize_history_file(nc_file_struct *nc)
         log_err("Error adding attribute in %s", nc->fname);
     }
 
-    ndims = options.COORD_DIMS_OUT;
+    ndims = global_domain.info.n_coord_dims;
     dstart[0] = 0;
     dstart[1] = 0;
 
-    if (options.COORD_DIMS_OUT == 1) {
+    if (global_domain.info.n_coord_dims == 1) {
         dimids[0] = nc->ni_dimid;
         dcount[0] = nc->ni_size;
     }
-    else if (options.COORD_DIMS_OUT == 2) {
+    else if (global_domain.info.n_coord_dims == 2) {
         dimids[0] = nc->nj_dimid;
         dcount[0] = nc->nj_size;
 
@@ -317,11 +302,11 @@ initialize_history_file(nc_file_struct *nc)
         dcount[1] = nc->ni_size;
     }
     else {
-        log_err("COORD_DIMS_OUT should be 1 or 2");
+        log_err("n_coord_dims should be 1 or 2");
     }
 
     // define the netcdf variable longitude
-    status = nc_def_var(nc->nc_id, options.DOMAIN_LON_VAR, NC_DOUBLE, ndims,
+    status = nc_def_var(nc->nc_id, global_domain.info.lon_var, NC_DOUBLE, ndims,
                         dimids, &(lon_var_id));
     if (status != NC_NOERR) {
         log_err("Error defining lon variable in %s", nc->fname);
@@ -343,13 +328,13 @@ initialize_history_file(nc_file_struct *nc)
         log_err("Error adding attribute in %s", nc->fname);
     }
 
-    if (options.COORD_DIMS_OUT == 1) {
+    if (global_domain.info.n_coord_dims == 1) {
         dimids[0] = nc->nj_dimid;
         dcount[0] = nc->nj_size;
     }
 
     // define the netcdf variable latitude
-    status = nc_def_var(nc->nc_id, options.DOMAIN_LAT_VAR, NC_DOUBLE, ndims,
+    status = nc_def_var(nc->nc_id, global_domain.info.lat_var, NC_DOUBLE, ndims,
                         dimids, &(lat_var_id));
     if (status != NC_NOERR) {
         log_err("Error defining lat variable in %s", nc->fname);
@@ -377,7 +362,7 @@ initialize_history_file(nc_file_struct *nc)
     }
 
     // fill the netcdf variables lat/lon
-    if (options.COORD_DIMS_OUT == 1) {
+    if (global_domain.info.n_coord_dims == 1) {
         dvar = calloc(nc->ni_size, sizeof(*dvar));
 
         dcount[0] = nc->ni_size;
@@ -405,7 +390,7 @@ initialize_history_file(nc_file_struct *nc)
         }
         free(dvar);
     }
-    else if (options.COORD_DIMS_OUT == 2) {
+    else if (global_domain.info.n_coord_dims == 2) {
         dvar = calloc(nc->nj_size * nc->ni_size, sizeof(*dvar));
 
         for (i = 0; i < nc->nj_size * nc->ni_size; i++) {
@@ -429,6 +414,6 @@ initialize_history_file(nc_file_struct *nc)
         free(dvar);
     }
     else {
-        log_err("COORD_DIMS_OUT should be 1 or 2");
+        log_err("n_coord_dims should be 1 or 2");
     }
 }

--- a/vic/drivers/image/src/vic_nc_info.c
+++ b/vic/drivers/image/src/vic_nc_info.c
@@ -112,8 +112,7 @@ vic_nc_info(nc_file_struct   *nc_hist_file,
         case OUT_LATENT_BAND:
         case OUT_LATENT_SUB_BAND:
         case OUT_MELT_ENERGY_BAND:
-        case OUT_NET_LONG_BAND:
-        case OUT_NET_SHORT_BAND:
+        case OUT_LWNET_BAND:
         case OUT_RFRZ_ENERGY_BAND:
         case OUT_SENSIBLE_BAND:
         case OUT_SNOW_CANOPY_BAND:
@@ -318,15 +317,15 @@ vic_nc_info(nc_file_struct   *nc_hist_file,
         case OUT_LATENT:
         case OUT_LATENT_SUB:
         case OUT_MELT_ENERGY:
-        case OUT_NET_LONG:
-        case OUT_NET_SHORT:
+        case OUT_LWNET:
+        case OUT_SWNET:
         case OUT_R_NET:
         case OUT_RFRZ_ENERGY:
         case OUT_SENSIBLE:
         case OUT_SNOW_FLUX:
-        case OUT_LONGWAVE:
+        case OUT_LWDOWN:
         case OUT_PAR:
-        case OUT_SHORTWAVE:
+        case OUT_SWDOWN:
         case OUT_ADV_SENS_BAND:
         case OUT_ADVECTION_BAND:
         case OUT_DELTACC_BAND:
@@ -335,8 +334,7 @@ vic_nc_info(nc_file_struct   *nc_hist_file,
         case OUT_LATENT_BAND:
         case OUT_LATENT_SUB_BAND:
         case OUT_MELT_ENERGY_BAND:
-        case OUT_NET_LONG_BAND:
-        case OUT_NET_SHORT_BAND:
+        case OUT_SWNET_BAND:
         case OUT_RFRZ_ENERGY_BAND:
         case OUT_SENSIBLE_BAND:
         case OUT_SNOW_FLUX_BAND:

--- a/vic/drivers/image/src/vic_start.c
+++ b/vic/drivers/image/src/vic_start.c
@@ -66,6 +66,9 @@ vic_start(void)
     initialize_filenames();
 
     if (mpi_rank == 0) {
+        // Initialize the global domain
+        initialize_domain(&global_domain);
+
         // read global settings
         filep.globalparam = open_file(filenames.global, "r");
         get_global_param(filep.globalparam);

--- a/vic/drivers/python/vic_headers.py
+++ b/vic/drivers/python/vic_headers.py
@@ -71,13 +71,13 @@ enum
     FCANOPY,
     FDIR,
     LAI_IN,
-    LONGWAVE,
+    LWDOWN,
     PAR,
     PREC,
     PRESSURE,
     QAIR,
     REL_HUMID,
-    SHORTWAVE,
+    SWDOWN,
     VP,
     WIND,
     SKIP,
@@ -186,8 +186,8 @@ enum
     OUT_LATENT,
     OUT_LATENT_SUB,
     OUT_MELT_ENERGY,
-    OUT_NET_LONG,
-    OUT_NET_SHORT,
+    OUT_LWNET,
+    OUT_SWNET,
     OUT_R_NET,
     OUT_RFRZ_ENERGY,
     OUT_SENSIBLE,
@@ -205,12 +205,12 @@ enum
     OUT_FCANOPY,
     OUT_FDIR,
     OUT_LAI,
-    OUT_LONGWAVE,
+    OUT_LWDOWN,
     OUT_PAR,
     OUT_PRESSURE,
     OUT_QAIR,
     OUT_REL_HUMID,
-    OUT_SHORTWAVE,
+    OUT_SWDOWN,
     OUT_SURF_COND,
     OUT_TSKC,
     OUT_VP,
@@ -225,8 +225,8 @@ enum
     OUT_LATENT_BAND,
     OUT_LATENT_SUB_BAND,
     OUT_MELT_ENERGY_BAND,
-    OUT_NET_LONG_BAND,
-    OUT_NET_SHORT_BAND,
+    OUT_LWNET_BAND,
+    OUT_SWNET_BAND,
     OUT_RFRZ_ENERGY_BAND,
     OUT_SENSIBLE_BAND,
     OUT_SNOW_CANOPY_BAND,
@@ -1250,6 +1250,7 @@ typedef struct {
     _Bool SIGNED;
     _Bool SUPPLIED;
     double multiplier;
+    char varname[2048];
 } force_type_struct;
 typedef struct {
     force_type_struct TYPE[N_FORCING_TYPES];

--- a/vic/drivers/shared/include/vic_driver_shared.h
+++ b/vic/drivers/shared/include/vic_driver_shared.h
@@ -77,12 +77,12 @@ enum
     FCANOPY,     /**< fractional area covered by plant canopy [fraction] */
     FDIR,        /**< fraction of incoming shortwave that is direct [fraction] */
     LAI_IN,      /**< leaf area index [m2/m2] */
-    LONGWAVE,    /**< incoming longwave radiation [W/m2] */
+    LWDOWN,      /**< incoming longwave radiation [W/m2] */
     PAR,         /**< incoming photosynthetically active radiation [W/m2] */
     PREC,        /**< total precipitation (rain and snow) [mm] */
     PRESSURE,    /**< atmospheric pressure [kPa] */
     VP,          /**< vapor pressure [kPa] */
-    SHORTWAVE,   /**< incoming shortwave [W/m2] */
+    SWDOWN,      /**< incoming shortwave [W/m2] */
     WIND,        /**< wind speed [m/s] */
     SKIP,        /**< place holder for unused data columns */
     // Last value of enum - DO NOT ADD ANYTHING BELOW THIS LINE!!
@@ -201,8 +201,8 @@ enum
     OUT_LATENT,           /**< net upward latent heat flux [W/m2] */
     OUT_LATENT_SUB,       /**< net upward latent heat flux from sublimation [W/m2] */
     OUT_MELT_ENERGY,      /**< energy of fusion (melting) in snowpack [W/m2] */
-    OUT_NET_LONG,         /**< net downward longwave flux [W/m2] */
-    OUT_NET_SHORT,        /**< net downward shortwave flux [W/m2] */
+    OUT_LWNET,            /**< net downward longwave flux [W/m2] */
+    OUT_SWNET,            /**< net downward shortwave flux [W/m2] */
     OUT_R_NET,            /**< net downward radiation flux [W/m2] */
     OUT_RFRZ_ENERGY,      /**< net energy used to refreeze liquid water in snowpack [W/m2] */
     OUT_SENSIBLE,         /**< net upward sensible heat flux [W/m2] */
@@ -220,12 +220,12 @@ enum
     OUT_FCANOPY,          /**< fractional area covered by plant canopy [fraction] */
     OUT_FDIR,             /**< fraction of incoming shortwave that is direct [fraction]*/
     OUT_LAI,              /**< leaf area index [m2/m2] */
-    OUT_LONGWAVE,         /**< incoming longwave [W/m2] */
+    OUT_LWDOWN,           /**< incoming longwave [W/m2] */
     OUT_PAR,              /**< incoming photosynthetically active radiation [W/m2] */
     OUT_PRESSURE,         /**< near surface atmospheric pressure [kPa] (ALMA_OUTPUT: [Pa])*/
     OUT_QAIR,             /**< specific humidity [kg/kg] */
     OUT_REL_HUMID,        /**< relative humidity [%]*/
-    OUT_SHORTWAVE,        /**< incoming shortwave [W/m2] */
+    OUT_SWDOWN,           /**< incoming shortwave [W/m2] */
     OUT_SURF_COND,        /**< surface conductance [m/s] */
     OUT_VP,               /**< near surface vapor pressure [kPa] (ALMA_OUTPUT: [Pa]) */
     OUT_VPD,              /**< near surface vapor pressure deficit [kPa] (ALMA_OUTPUT: [Pa]) */
@@ -240,8 +240,8 @@ enum
     OUT_LATENT_BAND,      /**< net upward latent heat flux [W/m2] */
     OUT_LATENT_SUB_BAND,  /**< net upward latent heat flux due to sublimation [W/m2] */
     OUT_MELT_ENERGY_BAND, /**< energy of fusion (melting) in snowpack [W/m2] */
-    OUT_NET_LONG_BAND,    /**< net downward longwave flux [W/m2] */
-    OUT_NET_SHORT_BAND,   /**< net downward shortwave flux [W/m2] */
+    OUT_LWNET_BAND,       /**< net downward longwave flux [W/m2] */
+    OUT_SWNET_BAND,       /**< net downward shortwave flux [W/m2] */
     OUT_RFRZ_ENERGY_BAND, /**< net energy used to refreeze liquid water in snowpack [W/m2] */
     OUT_SENSIBLE_BAND,    /**< net upward sensible heat flux [W/m2] */
     OUT_SNOW_CANOPY_BAND, /**< snow interception storage in canopy [mm] */
@@ -343,6 +343,7 @@ typedef struct {
     bool SIGNED;
     bool SUPPLIED;
     double multiplier;
+    char varname[MAXSTRING];
 } force_type_struct;
 
 /******************************************************************************
@@ -449,6 +450,7 @@ void collect_wb_terms(cell_data_struct, veg_var_struct, snow_data_struct,
 void compute_lake_params(lake_con_struct *, soil_con_struct);
 void compute_treeline(atmos_data_struct *, dmy_struct *, double, double *,
                       bool *);
+size_t count_force_vars(FILE *gp);
 void cmd_proc(int argc, char **argv, char *globalfilename);
 void compress_files(char string[]);
 out_data_struct *create_output_list(void);

--- a/vic/drivers/shared/src/forcing_utils.c
+++ b/vic/drivers/shared/src/forcing_utils.c
@@ -121,3 +121,50 @@ will_it_snow(double *t,
 
     return 0;
 }
+
+/******************************************************************************
+ * @brief    This routine determines the counts the number of forcing variables
+             in each forcing file specified in the global parameter file.
+ *****************************************************************************/
+size_t
+count_force_vars(FILE *gp)
+{
+    size_t        nvars;
+    unsigned long start_position;
+    char          cmdstr[MAXSTRING];
+    char          optstr[MAXSTRING];
+
+    // Figure out where we are in the input file
+    fflush(gp);
+    start_position = ftell(gp);
+
+    // read the first line
+    fgets(cmdstr, MAXSTRING, gp);
+
+    // initalize nvars
+    nvars = 0;
+
+    // Loop through the lines
+    while (!feof(gp)) {
+        if (cmdstr[0] != '#' && cmdstr[0] != '\n' && cmdstr[0] != '\0') {
+            // line is not blank or a comment
+            sscanf(cmdstr, "%s", optstr);
+
+            // if the line starts with FORCE_TYPE
+            if (strcasecmp("FORCE_TYPE", optstr) == 0) {
+                nvars++;
+            }
+            // else if we arive at another forcing file break out of loop
+            else if (strcasecmp("FORCING1", optstr) == 0 ||
+                     strcasecmp("FORCING2", optstr) == 0) {
+                break;
+            }
+        }
+        fgets(cmdstr, MAXSTRING, gp);
+    }
+
+    // put the position in the file back to where we started
+    fseek(gp, start_position, SEEK_SET);
+
+    return nvars;
+}

--- a/vic/drivers/shared/src/output_list_utils.c
+++ b/vic/drivers/shared/src/output_list_utils.c
@@ -148,8 +148,8 @@ create_output_list()
     strcpy(out_data[OUT_LATENT].varname, "OUT_LATENT");                /* net upward latent heat flux [W/m2] */
     strcpy(out_data[OUT_LATENT_SUB].varname, "OUT_LATENT_SUB");        /* net upward latent heat flux from sublimation [W/m2] */
     strcpy(out_data[OUT_MELT_ENERGY].varname, "OUT_MELT_ENERGY");      /* energy of fusion (melting) [W/m2] */
-    strcpy(out_data[OUT_NET_LONG].varname, "OUT_NET_LONG");            /* net downward longwave flux [W/m2] */
-    strcpy(out_data[OUT_NET_SHORT].varname, "OUT_NET_SHORT");          /* net downward shortwave flux [W/m2] */
+    strcpy(out_data[OUT_LWNET].varname, "OUT_LWNET");                  /* net downward longwave flux [W/m2] */
+    strcpy(out_data[OUT_SWNET].varname, "OUT_SWNET");                  /* net downward shortwave flux [W/m2] */
     strcpy(out_data[OUT_R_NET].varname, "OUT_R_NET");                  /* net downward radiation flux [W/m2] */
     strcpy(out_data[OUT_RFRZ_ENERGY].varname, "OUT_RFRZ_ENERGY");      /* net energy used to refreeze liquid water in snowpack [W/m2] */
     strcpy(out_data[OUT_SENSIBLE].varname, "OUT_SENSIBLE");            /* net upward sensible heat flux [W/m2] */
@@ -168,12 +168,12 @@ create_output_list()
     strcpy(out_data[OUT_FCANOPY].varname, "OUT_FCANOPY");              /* fractional area covered by plant canopy [fraction] */
     strcpy(out_data[OUT_FDIR].varname, "OUT_FDIR");                    /* fraction of incoming shortwave that is direct [fraction] */
     strcpy(out_data[OUT_LAI].varname, "OUT_LAI");                      /* leaf area index [m2/m2] */
-    strcpy(out_data[OUT_LONGWAVE].varname, "OUT_LONGWAVE");            /* incoming longwave [W/m2] */
+    strcpy(out_data[OUT_LWDOWN].varname, "OUT_LWDOWN");                /* incoming longwave [W/m2] */
     strcpy(out_data[OUT_PAR].varname, "OUT_PAR");                      /* incoming photosynthetically active radiation [W/m2] */
     strcpy(out_data[OUT_PRESSURE].varname, "OUT_PRESSURE");            /* near surface atmospheric pressure [kPa] */
     strcpy(out_data[OUT_QAIR].varname, "OUT_QAIR");                    /* specific humidity [kg/kg] */
     strcpy(out_data[OUT_REL_HUMID].varname, "OUT_REL_HUMID");          /* relative humidity [fraction]*/
-    strcpy(out_data[OUT_SHORTWAVE].varname, "OUT_SHORTWAVE");          /* incoming shortwave [W/m2] */
+    strcpy(out_data[OUT_SWDOWN].varname, "OUT_SWDOWN");                /* incoming shortwave [W/m2] */
     strcpy(out_data[OUT_SURF_COND].varname, "OUT_SURF_COND");          /* surface conductance [m/s] */
     strcpy(out_data[OUT_VP].varname, "OUT_VP");                        /* near surface vapor pressure [kPa] */
     strcpy(out_data[OUT_VPD].varname, "OUT_VPD");                      /* near surface vapor pressure deficit [kPa] */
@@ -201,8 +201,8 @@ create_output_list()
     strcpy(out_data[OUT_LATENT_BAND].varname, "OUT_LATENT_BAND");                /* net upward latent heat flux [W/m2] */
     strcpy(out_data[OUT_LATENT_SUB_BAND].varname, "OUT_LATENT_SUB_BAND");        /* net upward latent heat flux from sublimation [W/m2] */
     strcpy(out_data[OUT_MELT_ENERGY_BAND].varname, "OUT_MELT_ENERGY_BAND");      /* energy of fusion (melting) [W/m2] */
-    strcpy(out_data[OUT_NET_LONG_BAND].varname, "OUT_NET_LONG_BAND");            /* net downward longwave flux [W/m2] */
-    strcpy(out_data[OUT_NET_SHORT_BAND].varname, "OUT_NET_SHORT_BAND");          /* net downward shortwave flux [W/m2] */
+    strcpy(out_data[OUT_LWNET_BAND].varname, "OUT_LWNET_BAND");                  /* net downward longwave flux [W/m2] */
+    strcpy(out_data[OUT_SWNET_BAND].varname, "OUT_SWNET_BAND");                  /* net downward shortwave flux [W/m2] */
     strcpy(out_data[OUT_RFRZ_ENERGY_BAND].varname, "OUT_RFRZ_ENERGY_BAND");      /* net energy used to refreeze liquid water in snowpack [W/m2] */
     strcpy(out_data[OUT_SENSIBLE_BAND].varname, "OUT_SENSIBLE_BAND");            /* net upward sensible heat flux [W/m2] */
     strcpy(out_data[OUT_SNOW_CANOPY_BAND].varname, "OUT_SNOW_CANOPY_BAND");      /* snow interception storage in canopy [mm] */
@@ -240,8 +240,8 @@ create_output_list()
     out_data[OUT_LATENT_BAND].nelem = options.SNOW_BAND;
     out_data[OUT_LATENT_SUB_BAND].nelem = options.SNOW_BAND;
     out_data[OUT_MELT_ENERGY_BAND].nelem = options.SNOW_BAND;
-    out_data[OUT_NET_LONG_BAND].nelem = options.SNOW_BAND;
-    out_data[OUT_NET_SHORT_BAND].nelem = options.SNOW_BAND;
+    out_data[OUT_LWNET_BAND].nelem = options.SNOW_BAND;
+    out_data[OUT_SWNET_BAND].nelem = options.SNOW_BAND;
     out_data[OUT_RFRZ_ENERGY_BAND].nelem = options.SNOW_BAND;
     out_data[OUT_SENSIBLE_BAND].nelem = options.SNOW_BAND;
     out_data[OUT_SNOW_CANOPY_BAND].nelem = options.SNOW_BAND;

--- a/vic/drivers/shared/src/put_data.c
+++ b/vic/drivers/shared/src/put_data.c
@@ -153,7 +153,7 @@ put_data(all_vars_struct   *all_vars,
     // Set output versions of input forcings
     out_data[OUT_AIR_TEMP].data[0] = atmos->air_temp[NR];
     out_data[OUT_DENSITY].data[0] = atmos->density[NR];
-    out_data[OUT_LONGWAVE].data[0] = atmos->longwave[NR];
+    out_data[OUT_LWDOWN].data[0] = atmos->longwave[NR];
     out_data[OUT_PREC].data[0] = atmos->out_prec;  // mm over grid cell
     out_data[OUT_PRESSURE].data[0] = atmos->pressure[NR] / PA_PER_KPA;
     out_data[OUT_QAIR].data[0] = CONST_EPS * atmos->vp[NR] /
@@ -167,7 +167,7 @@ put_data(all_vars_struct   *all_vars,
     else {
         out_data[OUT_LAKE_CHAN_IN].data[0] = 0;
     }
-    out_data[OUT_SHORTWAVE].data[0] = atmos->shortwave[NR];
+    out_data[OUT_SWDOWN].data[0] = atmos->shortwave[NR];
     out_data[OUT_SNOWF].data[0] = atmos->out_snow;   // mm over grid cell
     out_data[OUT_VP].data[0] = atmos->vp[NR] / PA_PER_KPA;
     out_data[OUT_VPD].data[0] = atmos->vpd[NR] / PA_PER_KPA;
@@ -537,8 +537,8 @@ put_data(all_vars_struct   *all_vars,
     // Energy terms
     out_data[OUT_REFREEZE].data[0] =
         (out_data[OUT_RFRZ_ENERGY].data[0] / CONST_LATICE) * dt_sec;
-    out_data[OUT_R_NET].data[0] = out_data[OUT_NET_SHORT].data[0] +
-                                  out_data[OUT_NET_LONG].data[0];
+    out_data[OUT_R_NET].data[0] = out_data[OUT_SWNET].data[0] +
+                                  out_data[OUT_LWNET].data[0];
 
     // Save current moisture state for use in next time step
     save_data->total_soil_moist = 0;
@@ -588,8 +588,8 @@ put_data(all_vars_struct   *all_vars,
     if (options.FULL_ENERGY) {
         out_data[OUT_ENERGY_ERROR].data[0] = \
             calc_energy_balance_error(rec,
-                                      out_data[OUT_NET_SHORT].data[0] +
-                                      out_data[OUT_NET_LONG].data[0],
+                                      out_data[OUT_SWNET].data[0] +
+                                      out_data[OUT_LWNET].data[0],
                                       out_data[OUT_LATENT].data[0] +
                                       out_data[OUT_LATENT_SUB].data[0],
                                       out_data[OUT_SENSIBLE].data[0] +
@@ -1000,10 +1000,10 @@ collect_eb_terms(energy_bal_struct energy,
     *Tcanopy_fbcount_total += energy.Tcanopy_fbcount;
 
     /** record net shortwave radiation **/
-    out_data[OUT_NET_SHORT].data[0] += energy.NetShortAtmos * AreaFactor;
+    out_data[OUT_SWNET].data[0] += energy.NetShortAtmos * AreaFactor;
 
     /** record net longwave radiation **/
-    out_data[OUT_NET_LONG].data[0] += energy.NetLongAtmos * AreaFactor;
+    out_data[OUT_LWNET].data[0] += energy.NetLongAtmos * AreaFactor;
 
     /** record incoming longwave radiation at ground surface (under veg) **/
     if (snow.snow && overstory) {
@@ -1130,11 +1130,11 @@ collect_eb_terms(energy_bal_struct energy,
                                                 lakefactor;
 
     /** record band net downwards shortwave radiation **/
-    out_data[OUT_NET_SHORT_BAND].data[band] += energy.NetShortAtmos * Cv *
+    out_data[OUT_SWNET_BAND].data[band] += energy.NetShortAtmos * Cv *
                                                lakefactor;
 
     /** record band net downwards longwave radiation **/
-    out_data[OUT_NET_LONG_BAND].data[band] += energy.NetLongAtmos * Cv *
+    out_data[OUT_LWNET_BAND].data[band] += energy.NetLongAtmos * Cv *
                                               lakefactor;
 
     /** record band albedo **/

--- a/vic/vic_run/include/vic_def.h
+++ b/vic/vic_run/include/vic_def.h
@@ -318,9 +318,6 @@ typedef struct {
     bool COMPRESS;       /**< TRUE = Compress all output files */
     bool MOISTFRACT;     /**< TRUE = output soil moisture as fractional moisture content */
     size_t Noutfiles;    /**< Number of output files (not including state files) */
-    int COORD_DIMS_OUT;    /**< Number of output dimensions for lat and lon variables. COORD_DIMS_OUT 1 = lon(lon), lat(lat). COORD_DIMS_OUT 2 = lon(xc, yc), lat(xc, yc) */
-    char DOMAIN_LON_VAR[MAXSTRING];    /**< Name of the variable and the dimension of longitude in the output file */
-    char DOMAIN_LAT_VAR[MAXSTRING];    /**< Name of the variable and the dimension of latitude in the output file */
     bool PRT_HEADER;     /**< TRUE = insert header at beginning of output file; FALSE = no header */
     bool PRT_SNOW_BAND;  /**< TRUE = print snow parameters for each snow band. This is only used when default
                                    output files are used (for backwards-compatibility); if outfiles and


### PR DESCRIPTION
This PR closes #211.  Forcing variables can be specified in the global parameter following the convention proposed in #211.

~~blocked by #378~~