### PR TITLE
Fixed output file bugs in classic mode.

### DIFF
--- a/vic/drivers/classic/src/parse_output_info.c
+++ b/vic/drivers/classic/src/parse_output_info.c
@@ -49,6 +49,7 @@ parse_output_info(FILE                  *gp,
     int                  type;
     char                 multstr[MAXSTRING];
     double               mult;
+    size_t               noutfiles;    
 
     strcpy(format, "*");
 
@@ -60,7 +61,13 @@ parse_output_info(FILE                  *gp,
     outvarnum = 0;
 
     // Count the number of output files listed in the global param file
-    options.Noutfiles = count_n_outfiles(gp);
+    noutfiles = count_n_outfiles(gp);
+    if (noutfiles > 0) {
+        options.Noutfiles = noutfiles;
+    }
+    else {
+        return;
+    }
 
     // only parse the output info if there are output files to parse
     if (options.Noutfiles > 0) {
@@ -232,10 +239,6 @@ count_n_outfiles(FILE *gp)
             // if the line starts with OUTFILE
             if (strcasecmp("OUTFILE", optstr) == 0) {
                 n_outfiles++;
-            }
-            // else we're done with this file so break out of loop
-            else {
-                break;
             }
         }
         fgets(cmdstr, MAXSTRING, gp);

--- a/vic/drivers/classic/src/parse_output_info.c
+++ b/vic/drivers/classic/src/parse_output_info.c
@@ -49,7 +49,7 @@ parse_output_info(FILE                  *gp,
     int                  type;
     char                 multstr[MAXSTRING];
     double               mult;
-    size_t               noutfiles;    
+    size_t               noutfiles;
 
     strcpy(format, "*");
 

--- a/vic/drivers/classic/src/vic_classic.c
+++ b/vic/drivers/classic/src/vic_classic.c
@@ -67,6 +67,7 @@ main(int   argc,
     int                   cellnum;
     int                   startrec;
     int                   ErrorFlag;
+    size_t                filenum;
     dmy_struct           *dmy;
     atmos_data_struct    *atmos;
     veg_hist_struct     **veg_hist;
@@ -114,6 +115,13 @@ main(int   argc,
     fclose(filep.globalparam);
     filep.globalparam = open_file(filenames.global, "r");
     parse_output_info(filep.globalparam, &out_data_files, out_data);
+    for (filenum = 0; filenum < options.Noutfiles; filenum++) {
+        if (out_data_files[filenum].nvars == 0) {
+            log_err("No output variables were set in OUTFILE %zu. "
+                    "Must set at least one output variable (OUTVAR) "
+                    "for each OUTFILE.", filenum+1);
+        }
+    }
 
     /** Check and Open Files **/
     check_files(&filep, &filenames);

--- a/vic/drivers/classic/src/vic_classic.c
+++ b/vic/drivers/classic/src/vic_classic.c
@@ -119,7 +119,7 @@ main(int   argc,
         if (out_data_files[filenum].nvars == 0) {
             log_err("No output variables were set in OUTFILE %zu. "
                     "Must set at least one output variable (OUTVAR) "
-                    "for each OUTFILE.", filenum+1);
+                    "for each OUTFILE.", filenum + 1);
         }
     }
 


### PR DESCRIPTION
When no OUTFILE specified in global file, output default files;
When OUTFILE is specified but no corresponding OUTVAR specified, raise
an error.