### PR TITLE
Fix/img final mem err

### DIFF
--- a/vic/drivers/image/src/vic_finalize.c
+++ b/vic/drivers/image/src/vic_finalize.c
@@ -85,13 +85,13 @@ vic_finalize(void)
             }
             free_veg_hist(&(veg_hist[i][j]));
         }
+        free_all_vars(&(all_vars[i]), veg_con[i][0].vegetat_type_num);
+        free_out_data(&(out_data[i]));
         free(veg_con_map[i].vidx);
         free(veg_con_map[i].Cv);
         free(veg_con[i]);
         free(veg_hist[i]);
         free(veg_lib[i]);
-        free_all_vars(&(all_vars[i]), veg_con[i][0].vegetat_type_num);
-        free_out_data(&(out_data[i]));
     }
     free(atmos);
     free(soil_con);


### PR DESCRIPTION
previous behavior was to free `vegcon` before calling `free_all_vars` which needed the number of veg types from `vegcon`.

The good news is that the memory debugger made it this far before complaining so things seem to be in good shape.