### PR TITLE
Miscellaneous lake fixes

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -121,6 +121,11 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 
 #### Bug Fixes:
 
+1. Miscellaneous fixes to lake module
+
+	Several lake processes (aerodynamic resistance, albedo, latent/sensible heat fluxes, net radiation, etc) were reported incorrectly or not at all in output files. This has been fixed. In addition, in the absence of an initial state file, lake temperatures were initialized to unrealistic temperatures (the air temperature of the first simulation time step). To fix this, we now initialize the lake temperature to annual average soil temperature.
+
+
 ------------------------------
 
 ## VIC 4.2.c [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.35302.svg)](http://dx.doi.org/10.5281/zenodo.35302)

--- a/vic/drivers/classic/src/initialize_model_state.c
+++ b/vic/drivers/classic/src/initialize_model_state.c
@@ -129,8 +129,7 @@ initialize_model_state(all_vars_struct     *all_vars,
         }
         ErrorFlag =
             initialize_lake(lake_var, lake_con, soil_con,
-                            &(cell[tmp_lake_idx][0]),
-                            surf_temp, 0);
+                            &(cell[tmp_lake_idx][0]), 0);
         if (ErrorFlag == ERROR) {
             return(ErrorFlag);
         }

--- a/vic/drivers/classic/src/read_soilparam.c
+++ b/vic/drivers/classic/src/read_soilparam.c
@@ -261,7 +261,7 @@ read_soilparam(FILE *soilparam,
                     "soil file");
         }
         sscanf(token, "%lf", &temp.avg_temp);
-        if (options.FULL_ENERGY &&
+        if ((options.FULL_ENERGY || options.LAKES) &&
             (temp.avg_temp > 100. || temp.avg_temp < -50)) {
             log_err("Need valid average soil temperature in degrees C to "
                     "run.  Full Energy model, %f is not acceptable.",

--- a/vic/drivers/shared_all/src/initialize_lake.c
+++ b/vic/drivers/shared_all/src/initialize_lake.c
@@ -34,7 +34,6 @@ initialize_lake(lake_var_struct  *lake,
                 lake_con_struct   lake_con,
                 soil_con_struct  *soil_con,
                 cell_data_struct *cell,
-                double            airtemp,
                 int               skip_hydro)
 {
     extern option_struct     options;
@@ -46,10 +45,8 @@ initialize_lake(lake_var_struct  *lake,
     double                   depth;
     double                   tmp_volume;
 
-    /*  Assume no ice present, lake completely equilibrated with atmosphere. */
-
     for (i = 0; i < MAX_LAKE_NODES; i++) {
-        lake->temp[i] = max(airtemp, 0.0);
+        lake->temp[i] = max(soil_con->avg_temp, 0.0);
     }
 
     lake->areai = 0.0;

--- a/vic/drivers/shared_image/src/vic_init.c
+++ b/vic/drivers/shared_image/src/vic_init.c
@@ -1550,8 +1550,7 @@ vic_init(void)
             }
             initialize_lake(&(all_vars[i].lake_var), lake_con[i],
                             &(soil_con[i]),
-                            &(all_vars[i].cell[tmp_lake_idx][0]),
-                            soil_con[i].avg_temp, 0);
+                            &(all_vars[i].cell[tmp_lake_idx][0]), 0);
         }
         initialize_energy(all_vars[i].energy, nveg);
     }

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -183,7 +183,7 @@ void iceform(double *, double *, double, double, double *, int, double, double,
              double, double *, double *, double *, double *, double);
 void icerad(double, double, double, double *, double *, double *);
 int initialize_lake(lake_var_struct *, lake_con_struct, soil_con_struct *,
-                    cell_data_struct *, double, int);
+                    cell_data_struct *, int);
 int lakeice(double, double, double, double, double, double *, double, double *,
             double *, double, double);
 void latent_heat_from_snow(double, double, double, double, double, double,

--- a/vic/vic_run/src/lakes.eb.c
+++ b/vic/vic_run/src/lakes.eb.c
@@ -406,7 +406,8 @@ solve_lake(double           snowfall,
             }
             lake->aero_resist =
                 (log((2. + param.LAKE_ZWATER) / param.LAKE_ZWATER) *
-                 log(wind_h / param.LAKE_ZWATER) / (von_K * von_K)) / windi;
+                 log(wind_h / param.LAKE_ZWATER) /
+                 (CONST_KARMAN * CONST_KARMAN)) / windi;
         }
         lake->soil.aero_resist[0] = lake->aero_resist;
 

--- a/vic/vic_run/src/lakes.eb.c
+++ b/vic/vic_run/src/lakes.eb.c
@@ -404,8 +404,9 @@ solve_lake(double           snowfall,
                 lake->hice = 0.0;
                 lake->ice_water_eq = 0.0;
             }
-            lake->aero_resist = (log((2. + ZWATER) / ZWATER)
-                                * log(wind_h/ZWATER) / (von_K*von_K)) / windi;
+            lake->aero_resist =
+                (log((2. + param.LAKE_ZWATER) / param.LAKE_ZWATER) *
+                 log(wind_h / param.LAKE_ZWATER) / (von_K * von_K)) / windi;
         }
         lake->soil.aero_resist[0] = lake->aero_resist;
 
@@ -838,7 +839,6 @@ eddy(int     freezeflag,
             de[k] = param.LAKE_DM;
         }
     }
-
     /**********************************************************************
     * Avoid too low wind speeds for computational stability.
     **********************************************************************/


### PR DESCRIPTION
This fix addresses several minor bugs.  Several lake processes (aerodynamic resistance, albedo, latent/sensible heat fluxes, net radiation, etc) were reported incorrectly or not at all in output files.  The fixes for those were all minor (1-liners).  Lake temperatures were initialized to unrealistic temperatures in the absence of an initial state file.  The fix for that was a little more involved: replaced the use of first step's air temperature with use of annual average soil temperature.

closes #405 
closes #406 
closes #419 
closes #420 
