### PR TITLE
Fixed a bug when read/write binary state file

### DIFF
--- a/vic/drivers/classic/include/vic_driver_classic.h
+++ b/vic/drivers/classic/include/vic_driver_classic.h
@@ -56,7 +56,7 @@ void init_output_list(out_data_struct *, int, char *, int, double);
 void initialize_forcing_files(void);
 void make_in_and_outfiles(filep_struct *, filenames_struct *, soil_con_struct *,
                           out_data_file_struct *);
-FILE *open_state_file(global_param_struct *, filenames_struct, int, int);
+FILE *open_state_file(global_param_struct *, filenames_struct, size_t, size_t);
 void print_atmos_data(atmos_data_struct *atmos, size_t nr);
 void parse_output_info(FILE *, out_data_file_struct **, out_data_struct *);
 void read_atmos_data(FILE *, global_param_struct, int, int, double **,

--- a/vic/drivers/classic/src/check_state_file.c
+++ b/vic/drivers/classic/src/check_state_file.c
@@ -69,8 +69,8 @@ check_state_file(char  *init_state_name,
 
     /* Check simulation options */
     if (options.STATE_FORMAT == BINARY) {
-        fread(&tmp_Nlayer, sizeof(int), 1, init_state);
-        fread(&tmp_Nnodes, sizeof(int), 1, init_state);
+        fread(&tmp_Nlayer, sizeof(size_t), 1, init_state);
+        fread(&tmp_Nnodes, sizeof(size_t), 1, init_state);
     }
     else {
         fscanf(init_state, "%zu %zu\n", &tmp_Nlayer, &tmp_Nnodes);

--- a/vic/drivers/classic/src/open_state_file.c
+++ b/vic/drivers/classic/src/open_state_file.c
@@ -32,8 +32,8 @@
 FILE *
 open_state_file(global_param_struct *global,
                 filenames_struct     filenames,
-                int                  Nlayer,
-                int                  Nnodes)
+                size_t               Nlayer,
+                size_t               Nnodes)
 {
     extern option_struct options;
 
@@ -62,11 +62,11 @@ open_state_file(global_param_struct *global,
 
     /* Write simulation flags */
     if (options.STATE_FORMAT == BINARY) {
-        fwrite(&Nlayer, sizeof(int), 1, statefile);
-        fwrite(&Nnodes, sizeof(int), 1, statefile);
+        fwrite(&Nlayer, sizeof(size_t), 1, statefile);
+        fwrite(&Nnodes, sizeof(size_t), 1, statefile);
     }
     else {
-        fprintf(statefile, "%i %i\n", Nlayer, Nnodes);
+        fprintf(statefile, "%zu %zu\n", Nlayer, Nnodes);
     }
 
     return(statefile);


### PR DESCRIPTION
The binary format state I/O did not run previously, due to inconsistent data type issue. Fixed this bug.