### PR TITLE
Fixed memory leaks in some functions.

### DIFF
--- a/vic/drivers/classic/include/vic_driver_classic.h
+++ b/vic/drivers/classic/include/vic_driver_classic.h
@@ -48,6 +48,7 @@ void compute_cell_area(soil_con_struct *);
 size_t count_outfile_nvars(FILE *gp);
 out_data_struct *create_output_list();
 void free_atmos(int nrecs, atmos_data_struct **atmos);
+void free_out_data_files(out_data_file_struct **);
 void free_veg_hist(int nrecs, int nveg, veg_hist_struct ***veg_hist);
 void free_veglib(veg_lib_struct **);
 double get_dist(double lat1, double long1, double lat2, double long2);

--- a/vic/drivers/classic/src/free_out_data_files.c
+++ b/vic/drivers/classic/src/free_out_data_files.c
@@ -1,0 +1,43 @@
+/******************************************************************************
+ * @section DESCRIPTION
+ *
+ * This routine frees the list of output files.
+ *
+ * @section LICENSE
+ *
+ * The Variable Infiltration Capacity (VIC) macroscale hydrological model
+ * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * and Environmental Engineering, University of Washington.
+ *
+ * The VIC model is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *****************************************************************************/
+
+#include <vic_driver_classic.h>
+
+/******************************************************************************
+ * @brief    This routine frees the memory in the out_data_files array.
+ *****************************************************************************/
+void
+free_out_data_files(out_data_file_struct **out_data_files)
+{
+    extern option_struct options;
+    size_t               filenum;
+
+    for (filenum = 0; filenum < options.Noutfiles; filenum++) {
+        free((char*) (*out_data_files)[filenum].varid);
+    }
+    free((char*) (*out_data_files));
+}
+

--- a/vic/drivers/classic/src/parse_output_info.c
+++ b/vic/drivers/classic/src/parse_output_info.c
@@ -60,16 +60,10 @@ parse_output_info(FILE                  *gp,
 
     // Count the number of output files listed in the global param file
     noutfiles = count_n_outfiles(gp);
-    if (noutfiles > 0) {
-        options.Noutfiles = noutfiles;
-    }
-    else {
-        return;
-    }
 
     // only parse the output info if there are output files to parse
-    if (options.Noutfiles > 0) {
-        free_out_data_files(out_data_files);
+    if (noutfiles > 0) {
+        options.Noutfiles = noutfiles;
 
         *out_data_files = calloc(options.Noutfiles, sizeof(*(*out_data_files)));
         if (*out_data_files == NULL) {
@@ -158,6 +152,10 @@ parse_output_info(FILE                  *gp,
             }
             fgets(cmdstr, MAXSTRING, gp);
         }
+    }
+    // Otherwise, set output files and their contents to default configuration
+    else {
+        *out_data_files = set_output_defaults(out_data);
     }
     fclose(gp);
 }

--- a/vic/drivers/classic/src/vic_classic.c
+++ b/vic/drivers/classic/src/vic_classic.c
@@ -96,6 +96,7 @@ main(int   argc,
     /** Read Global Control File **/
     filep.globalparam = open_file(filenames.global, "r");
     get_global_param(filep.globalparam);
+    fclose(filep.globalparam);
 
     // Set Log Destination
     setup_logging(MISSING);
@@ -110,8 +111,6 @@ main(int   argc,
 
     /** Set up output data structures **/
     out_data = create_output_list();
-    out_data_files = set_output_defaults(out_data);
-    fclose(filep.globalparam);
     filep.globalparam = open_file(filenames.global, "r");
     parse_output_info(filep.globalparam, &out_data_files, out_data);
     for (filenum = 0; filenum < options.Noutfiles; filenum++) {

--- a/vic/drivers/shared_all/include/vic_driver_shared_all.h
+++ b/vic/drivers/shared_all/include/vic_driver_shared_all.h
@@ -472,7 +472,6 @@ void display_current_settings(int);
 double fractional_day_from_dmy(dmy_struct *dmy);
 void free_all_vars(all_vars_struct *all_vars, int Nveg);
 void free_dmy(dmy_struct **dmy);
-void free_out_data_files(out_data_file_struct **);
 void free_out_data(out_data_struct **);
 void free_vegcon(veg_con_struct **veg_con);
 void generate_default_state(all_vars_struct *, soil_con_struct *,

--- a/vic/drivers/shared_all/src/output_list_utils.c
+++ b/vic/drivers/shared_all/src/output_list_utils.c
@@ -422,21 +422,6 @@ set_output_var(out_data_file_struct *out_data_files,
 }
 
 /******************************************************************************
- * @brief    This routine frees the memory in the out_data_files array.
- *****************************************************************************/
-void
-free_out_data_files(out_data_file_struct **out_data_files)
-{
-    extern option_struct options;
-    size_t               filenum;
-
-    for (filenum = 0; filenum < options.Noutfiles; filenum++) {
-        free((char*) (*out_data_files)[filenum].varid);
-    }
-    free((char*) (*out_data_files));
-}
-
-/******************************************************************************
  * @brief    This routine frees the memory in the out_data array.
  *****************************************************************************/
 void

--- a/vic/drivers/shared_image/src/alloc_atmos.c
+++ b/vic/drivers/shared_image/src/alloc_atmos.c
@@ -113,6 +113,8 @@ free_atmos(atmos_data_struct *atmos)
     }
 
     free(atmos->air_temp);
+    free(atmos->density);
+    free(atmos->longwave);
     free(atmos->prec);
     free(atmos->pressure);
     free(atmos->shortwave);

--- a/vic/drivers/shared_image/src/vic_finalize.c
+++ b/vic/drivers/shared_image/src/vic_finalize.c
@@ -52,6 +52,9 @@ vic_finalize(void)
     extern veg_con_struct    **veg_con;
     extern veg_hist_struct   **veg_hist;
     extern veg_lib_struct    **veg_lib;
+    extern MPI_Datatype mpi_nc_file_struct_type;
+    extern MPI_Datatype mpi_option_struct_type;
+    extern MPI_Datatype mpi_param_struct_type;
 
     size_t                     i;
     size_t                     j;
@@ -111,5 +114,8 @@ vic_finalize(void)
         free(mpi_map_global_array_offsets);
         free(mpi_map_mapping_array);
     }
+    MPI_Type_free(&mpi_nc_file_struct_type);
+    MPI_Type_free(&mpi_option_struct_type);
+    MPI_Type_free(&mpi_param_struct_type);
     finalize_logging();
 }

--- a/vic/drivers/shared_image/src/vic_finalize.c
+++ b/vic/drivers/shared_image/src/vic_finalize.c
@@ -85,7 +85,7 @@ vic_finalize(void)
             }
             free_veg_hist(&(veg_hist[i][j]));
         }
-        free_all_vars(&(all_vars[i]), veg_con[i][0].vegetat_type_num);
+        free_all_vars(&(all_vars[i]), veg_con_map[i].nv_active);
         free_out_data(&(out_data[i]));
         free(veg_con_map[i].vidx);
         free(veg_con_map[i].Cv);
@@ -103,8 +103,7 @@ vic_finalize(void)
     free(out_data);
     free(save_data);
     free(local_domain.locations);
-    // TODO: free dmy for image driver only
-    // free(dmy);
+    free(dmy);
     if (mpi_rank == 0) {
         free(filter_active_cells);
         free(global_domain.locations);

--- a/vic/drivers/shared_image/src/vic_init.c
+++ b/vic/drivers/shared_image/src/vic_init.c
@@ -1557,4 +1557,5 @@ vic_init(void)
     // cleanup
     free(dvar);
     free(ivar);
+    free(Cv_sum);
 }


### PR DESCRIPTION
This PR fixes the following memory leaks in VIC 5.0 (from issue #463 ):

Image Driver:
```shell
vic_init.c: 74
alloc_atmos.c: 41, 45
make_veg_var.c: 46
make_snow_data.c: 50
make_cell_data.c: 44
make_energy_bal.c: 49
```

Classic Driver:
```shell
set_output_defaults.c: 94
```

This does not (yet) completely resolve issue #463 but gets us part-way there, anyway.  If preferable, I can keep adding fixes to this PR until they're all fixed.