### PR TITLE
Removed some unused variables

### DIFF
--- a/vic/drivers/classic/src/vic_populate_model_state.c
+++ b/vic/drivers/classic/src/vic_populate_model_state.c
@@ -66,7 +66,7 @@ vic_populate_model_state(all_vars_struct *all_vars,
     Nveg = veg_con[0].vegetat_type_num;
 
     // Initialize all data structures to 0
-    initialize_soil(cell, soil_con, Nveg);
+    initialize_soil(cell, Nveg);
     initialize_snow(snow, Nveg);
     initialize_veg(veg_var, Nveg);
     if (options.LAKES) {

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -125,7 +125,7 @@ main(int    argc,
 
         // if save:
         if (check_save_state_flag(current)) {
-            vic_store(&(dmy[current]));
+            vic_store();
         }
     }
 

--- a/vic/drivers/shared_all/include/vic_driver_shared_all.h
+++ b/vic/drivers/shared_all/include/vic_driver_shared_all.h
@@ -489,8 +489,7 @@ void initialize_global(void);
 void initialize_options(void);
 void initialize_parameters(void);
 void initialize_snow(snow_data_struct **snow, size_t veg_num);
-void initialize_soil(cell_data_struct **cell, soil_con_struct *soil_con,
-                     size_t veg_num);
+void initialize_soil(cell_data_struct **cell, size_t veg_num);
 void initialize_time(void);
 void initialize_veg(veg_var_struct **veg_var, size_t nveg);
 double julian_day_from_dmy(dmy_struct *dmy, unsigned short int calendar);

--- a/vic/drivers/shared_all/src/initialize_soil.c
+++ b/vic/drivers/shared_all/src/initialize_soil.c
@@ -32,7 +32,6 @@
  *****************************************************************************/
 void
 initialize_soil(cell_data_struct **cell,
-                soil_con_struct   *soil_con,
                 size_t             veg_num)
 {
     extern option_struct options;

--- a/vic/drivers/shared_image/include/vic_driver_shared_image.h
+++ b/vic/drivers/shared_image/include/vic_driver_shared_image.h
@@ -201,7 +201,7 @@ void vic_nc_info(nc_file_struct *nc_hist_file, out_data_struct **out_data,
                  nc_var_struct *nc_vars);
 void vic_restore(void);
 void vic_start(void);
-void vic_store(dmy_struct *dmy_current);
+void vic_store(void);
 void vic_write(dmy_struct *dmy_current);
 
 #endif

--- a/vic/drivers/shared_image/src/vic_finalize.c
+++ b/vic/drivers/shared_image/src/vic_finalize.c
@@ -36,7 +36,6 @@ vic_finalize(void)
     extern size_t             *mpi_map_mapping_array;
     extern all_vars_struct    *all_vars;
     extern atmos_data_struct  *atmos;
-    extern dmy_struct         *dmy;
     extern domain_struct       global_domain;
     extern domain_struct       local_domain;
     extern filep_struct        filep;

--- a/vic/drivers/shared_image/src/vic_init.c
+++ b/vic/drivers/shared_image/src/vic_init.c
@@ -1540,7 +1540,7 @@ vic_init(void)
     for (i = 0; i < local_domain.ncells_active; i++) {
         nveg = veg_con[i][0].vegetat_type_num;
         initialize_snow(all_vars[i].snow, nveg);
-        initialize_soil(all_vars[i].cell, &(soil_con[i]), nveg);
+        initialize_soil(all_vars[i].cell, nveg);
         initialize_veg(all_vars[i].veg_var, nveg);
         if (options.LAKES) {
             tmp_lake_idx = (int)lake_con[i].lake_idx;

--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -30,7 +30,7 @@
  * @brief    Save model state.
  *****************************************************************************/
 void
-vic_store(dmy_struct *dmy_current)
+vic_store(void)
 {
     extern size_t              current;
     extern dmy_struct         *dmy;


### PR DESCRIPTION
This PR is to address issue #489 - removed some unused variable warnings in VIC code, including:

- `soil_con` in `initialize_soil()`
- `dmy` in `vic_finalize()`
- `dmy_current` in `vic_store`