### PR TITLE
Fixed exact restart (temporarily) - classic and image drivers

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -159,10 +159,10 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 
 	Previously, VIC did not produce the same results (fluxes and states) if a simulation is separated into multiple shorter-period runs by saving the state variables and restarting. This was due to: 1) the MTCLIM algorithm resulted in slightly different sub-daily meteorological variable values for different length of forcing (MTCLIM is deprecated in the current version); 2) a few bugs resulting in inexact restart. The following bugs have been fixed:
 
-	- The prognostic state variable `energy.Tfoliage` (Foliage temperature) is now saved to the state file
-	- Two flux variables `energy.LongUnderOut` and `energy.snow_flux` are now saved to the state file. **TODO:** this is a temporary solution to ensure exact restart. A better way of handling the tw flux variables need to be done in the future (see [GH#479](https://github.com/UW-Hydro/VIC/issues/479))
+	- The prognostic state variable `energy.Tfoliage` (foliage temperature) is now saved to the state file
+	- Two flux variables `energy.LongUnderOut` and `energy.snow_flux` are now saved to the state file. **TODO:** this is a temporary solution to ensure exact restart. A better way of handling the two flux variables needs to be done in the future (see [GH#479](https://github.com/UW-Hydro/VIC/issues/479))
 
-4. Fix the binary state file I/O ([GH#487](https://github.com/UW-Hydro/VIC/pull/487))
+4. Fix for binary state file I/O ([GH#487](https://github.com/UW-Hydro/VIC/pull/487))
 
 	Fixed a bug so that the binary format state file I/O works correctly.
 

--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -155,6 +155,17 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 
 	Previously, if the soil thermal damping depth was shallower than the bottom of the deepest soil layer, and `FROZEN_SOIL==TRUE`, VIC would abort when estimating layer ice contents because it could not estimate a layer temperature if the thermal nodes did not completely span the layer.  Now, a layer temperature is estimated even when thermal nodes do not completely span the layer, and the error no longer occurs.
 
+3. Fix related to exact restart ([GH#481](https://github.com/UW-Hydro/VIC/pull/481), [GH#507](https://github.com/UW-Hydro/VIC/pull/507))
+
+	Previously, VIC did not produce the same results (fluxes and states) if a simulation is separated into multiple shorter-period runs by saving the state variables and restarting. This was due to: 1) the MTCLIM algorithm resulted in slightly different sub-daily meteorological variable values for different length of forcing (MTCLIM is deprecated in the current version); 2) a few bugs resulting in inexact restart. The following bugs have been fixed:
+
+	- The prognostic state variable `energy.Tfoliage` (Foliage temperature) is now saved to the state file
+	- Two flux variables `energy.LongUnderOut` and `energy.snow_flux` are now saved to the state file. **TODO:** this is a temporary solution to ensure exact restart. A better way of handling the tw flux variables need to be done in the future (see [GH#479](https://github.com/UW-Hydro/VIC/issues/479))
+
+4. Fix the binary state file I/O ([GH#487](https://github.com/UW-Hydro/VIC/pull/487))
+
+	Fixed a bug so that the binary format state file I/O works correctly.
+
 ------------------------------
 
 ## VIC 4.2.c [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.35302.svg)](http://dx.doi.org/10.5281/zenodo.35302)

--- a/vic/drivers/classic/src/read_initial_model_state.c
+++ b/vic/drivers/classic/src/read_initial_model_state.c
@@ -387,6 +387,36 @@ read_initial_model_state(FILE            *init_state,
                     log_err("End of model state file found unexpectedly");
                 }
             }
+
+            /* Read outgoing longwave from understory */
+            /* TO-DO: this is a flux. Saving it to the state file is a temporary solution! */
+            if (options.STATE_FORMAT == BINARY) {
+                if (fread(&energy[veg][band].LongUnderOut, sizeof(double), 1,
+                          init_state) != 1) {
+                    log_err("End of model state file found unexpectedly");
+                }
+            }
+            else {
+                if (fscanf(init_state, " %lf",
+                           &energy[veg][band].LongUnderOut) == EOF) {
+                    log_err("End of model state file found unexpectedly");
+                }
+            }
+
+            /* Read thermal flux through the snow pack */
+            /* TO-DO: this is a flux. Saving it to the state file is a temporary solution! */
+            if (options.STATE_FORMAT == BINARY) {
+                if (fread(&energy[veg][band].snow_flux, sizeof(double), 1,
+                          init_state) != 1) {
+                    log_err("End of model state file found unexpectedly");
+                }
+            }
+            else {
+                if (fscanf(init_state, " %lf",
+                           &energy[veg][band].snow_flux) == EOF) {
+                    log_err("End of model state file found unexpectedly");
+                }
+            }
         }
     }
     if (options.LAKES) {

--- a/vic/drivers/classic/src/read_initial_model_state.c
+++ b/vic/drivers/classic/src/read_initial_model_state.c
@@ -357,10 +357,6 @@ read_initial_model_state(FILE            *init_state,
                 }
                 snow[veg][band].MELTING = (char)tmp_char;
             }
-            if (snow[veg][band].density > 0.) {
-                snow[veg][band].depth = MM_PER_M * snow[veg][band].swq /
-                                        snow[veg][band].density;
-            }
 
             /* Read soil thermal node temperatures */
             for (nidx = 0; nidx < options.Nnode; nidx++) {

--- a/vic/drivers/classic/src/write_model_state.c
+++ b/vic/drivers/classic/src/write_model_state.c
@@ -100,7 +100,9 @@ write_model_state(all_vars_struct *all_vars,
                   (Nveg + 1) * Nbands * sizeof(char) + // MELTING
                   (Nveg + 1) * Nbands * sizeof(double) * 9 + // other snow parameters
                   (Nveg + 1) * Nbands * options.Nnode * sizeof(double) + // soil temperatures
-                  (Nveg + 1) * Nbands * sizeof(double); // Tfoliage
+                  (Nveg + 1) * Nbands * sizeof(double) + // Tfoliage
+                  (Nveg + 1) * Nbands * sizeof(double) + // energy.LongUnderOut
+                  (Nveg + 1) * Nbands * sizeof(double); // energy.snow_flux
         if (options.LAKES) {
             /* Lake/wetland tiles have lake-specific state vars */
             Nbytes += sizeof(int) + // activenod
@@ -320,6 +322,28 @@ write_model_state(all_vars_struct *all_vars,
             else {
                 fprintf(filep->statefile, " "ASCII_STATE_FLOAT_FMT,
                         energy[veg][band].Tfoliage);
+            }
+
+            /* Write outgoing longwave from understory */
+            /* TO-DO: this is a flux. Saving it to the state file is a temporary solution! */
+            if (options.STATE_FORMAT == BINARY) {
+                fwrite(&energy[veg][band].LongUnderOut, sizeof(double), 1,
+                       filep->statefile);
+            }
+            else {
+                fprintf(filep->statefile, " "ASCII_STATE_FLOAT_FMT,
+                        energy[veg][band].LongUnderOut);
+            }
+
+            /* Write thermal flux through the snow pack */
+            /* TO-DO: this is a flux. Saving it to the state file is a temporary solution! */
+            if (options.STATE_FORMAT == BINARY) {
+                fwrite(&energy[veg][band].snow_flux, sizeof(double), 1,
+                       filep->statefile);
+            }
+            else {
+                fprintf(filep->statefile, " "ASCII_STATE_FLOAT_FMT,
+                        energy[veg][band].snow_flux);
             }
 
             if (options.STATE_FORMAT == ASCII) {

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -85,7 +85,8 @@ vic_force(void)
 
     // Air temperature: tas
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[AIR_TEMP].varname,
                                     d3start, d3count, dvar);
@@ -96,7 +97,8 @@ vic_force(void)
 
     // Precipitation: prcp
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[PREC].varname,
                                     d3start, d3count, dvar);
@@ -107,7 +109,8 @@ vic_force(void)
 
     // Downward solar radiation: dswrf
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[SWDOWN].varname,
                                     d3start, d3count, dvar);
@@ -118,7 +121,8 @@ vic_force(void)
 
     // Downward longwave radiation: dlwrf
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[LWDOWN].varname,
                                     d3start, d3count, dvar);
@@ -129,7 +133,8 @@ vic_force(void)
 
     // Wind speed: wind
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[WIND].varname,
                                     d3start, d3count, dvar);
@@ -140,7 +145,8 @@ vic_force(void)
 
     // Specific humidity: shum
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[VP].varname,
                                     d3start, d3count, dvar);
@@ -151,7 +157,8 @@ vic_force(void)
 
     // Pressure: pressure
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[PRESSURE].varname,
                                     d3start, d3count, dvar);
@@ -162,7 +169,8 @@ vic_force(void)
     // Optional inputs
     if (options.LAKES) {
         // Channel inflow to lake
-        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] +
+                     j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[CHANNEL_IN].varname,
                                     d3start, d3count, dvar);
@@ -175,7 +183,8 @@ vic_force(void)
     if (options.CARBON) {
         // Atmospheric CO2 mixing ratio
         for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+            d3start[0] = global_param.forceskip[0] +
+                         global_param.forceoffset[0] + j;
             get_scatter_nc_field_double(filenames.forcing[0],
                                         param_set.TYPE[CATM].varname,
                                         d3start, d3count, dvar);
@@ -195,7 +204,8 @@ vic_force(void)
         }
         // Fraction of shortwave that is direct
         for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+            d3start[0] = global_param.forceskip[0] +
+                         global_param.forceoffset[0] + j;
             get_scatter_nc_field_double(filenames.forcing[0],
                                         param_set.TYPE[FDIR].varname,
                                         d3start, d3count, dvar);
@@ -205,7 +215,8 @@ vic_force(void)
         }
         // Photosynthetically active radiation
         for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
+            d3start[0] = global_param.forceskip[0] +
+                         global_param.forceoffset[0] + j;
             get_scatter_nc_field_double(filenames.forcing[0],
                                         param_set.TYPE[PAR].varname,
                                         d3start, d3count, dvar);
@@ -266,7 +277,8 @@ vic_force(void)
         // Leaf Area Index: lai
         if (options.LAI_SRC == FROM_VEGHIST) {
             for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceskip[1] + global_param.forceoffset[1] + j;
+                d4start[0] = global_param.forceskip[1] +
+                             global_param.forceoffset[1] + j;
                 for (v = 0; v < options.NVEGTYPES; v++) {
                     d4start[1] = v;
                     get_scatter_nc_field_double(filenames.forcing[1], "lai",
@@ -284,7 +296,8 @@ vic_force(void)
         // Partial veg cover fraction: fcov
         if (options.FCAN_SRC == FROM_VEGHIST) {
             for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceskip[1] + global_param.forceoffset[1] + j;
+                d4start[0] = global_param.forceskip[1] +
+                             global_param.forceoffset[1] + j;
                 for (v = 0; v < options.NVEGTYPES; v++) {
                     d4start[1] = v;
                     get_scatter_nc_field_double(filenames.forcing[1], "fcov",
@@ -302,7 +315,8 @@ vic_force(void)
         // Albedo: alb
         if (options.ALB_SRC == FROM_VEGHIST) {
             for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceskip[1] + global_param.forceoffset[1] + j;
+                d4start[0] = global_param.forceskip[1] +
+                             global_param.forceoffset[1] + j;
                 for (v = 0; v < options.NVEGTYPES; v++) {
                     d4start[1] = v;
                     get_scatter_nc_field_double(filenames.forcing[1], "alb",
@@ -458,7 +472,8 @@ get_forcing_file_info(param_set_struct *param_set,
     parse_nc_time_units(nc_unit_chars, &time_units, &nc_origin_dmy);
 
     // Get date/time of the first entry in the forcing file.
-    nc_time_origin = date2num(0., &nc_origin_dmy, 0., calendar, TIME_UNITS_DAYS);
+    nc_time_origin =
+        date2num(0., &nc_origin_dmy, 0., calendar, TIME_UNITS_DAYS);
     num2date(nc_time_origin, nc_times[0], 0., calendar, time_units,
              &nc_start_dmy);
 

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -85,7 +85,7 @@ vic_force(void)
 
     // Air temperature: tas
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[AIR_TEMP].varname,
                                     d3start, d3count, dvar);
@@ -96,7 +96,7 @@ vic_force(void)
 
     // Precipitation: prcp
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[PREC].varname,
                                     d3start, d3count, dvar);
@@ -107,7 +107,7 @@ vic_force(void)
 
     // Downward solar radiation: dswrf
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[SWDOWN].varname,
                                     d3start, d3count, dvar);
@@ -118,7 +118,7 @@ vic_force(void)
 
     // Downward longwave radiation: dlwrf
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[LWDOWN].varname,
                                     d3start, d3count, dvar);
@@ -129,7 +129,7 @@ vic_force(void)
 
     // Wind speed: wind
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[WIND].varname,
                                     d3start, d3count, dvar);
@@ -140,7 +140,7 @@ vic_force(void)
 
     // Specific humidity: shum
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[VP].varname,
                                     d3start, d3count, dvar);
@@ -151,7 +151,7 @@ vic_force(void)
 
     // Pressure: pressure
     for (j = 0; j < NF; j++) {
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[PRESSURE].varname,
                                     d3start, d3count, dvar);
@@ -162,7 +162,7 @@ vic_force(void)
     // Optional inputs
     if (options.LAKES) {
         // Channel inflow to lake
-        d3start[0] = global_param.forceoffset[0] + j;
+        d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
         get_scatter_nc_field_double(filenames.forcing[0],
                                     param_set.TYPE[CHANNEL_IN].varname,
                                     d3start, d3count, dvar);
@@ -175,7 +175,7 @@ vic_force(void)
     if (options.CARBON) {
         // Atmospheric CO2 mixing ratio
         for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceoffset[0] + j;
+            d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
             get_scatter_nc_field_double(filenames.forcing[0],
                                         param_set.TYPE[CATM].varname,
                                         d3start, d3count, dvar);
@@ -195,7 +195,7 @@ vic_force(void)
         }
         // Fraction of shortwave that is direct
         for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceoffset[0] + j;
+            d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
             get_scatter_nc_field_double(filenames.forcing[0],
                                         param_set.TYPE[FDIR].varname,
                                         d3start, d3count, dvar);
@@ -205,7 +205,7 @@ vic_force(void)
         }
         // Photosynthetically active radiation
         for (j = 0; j < NF; j++) {
-            d3start[0] = global_param.forceoffset[0] + j;
+            d3start[0] = global_param.forceskip[0] + global_param.forceoffset[0] + j;
             get_scatter_nc_field_double(filenames.forcing[0],
                                         param_set.TYPE[PAR].varname,
                                         d3start, d3count, dvar);
@@ -266,7 +266,7 @@ vic_force(void)
         // Leaf Area Index: lai
         if (options.LAI_SRC == FROM_VEGHIST) {
             for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceoffset[1] + j;
+                d4start[0] = global_param.forceskip[1] + global_param.forceoffset[1] + j;
                 for (v = 0; v < options.NVEGTYPES; v++) {
                     d4start[1] = v;
                     get_scatter_nc_field_double(filenames.forcing[1], "lai",
@@ -284,7 +284,7 @@ vic_force(void)
         // Partial veg cover fraction: fcov
         if (options.FCAN_SRC == FROM_VEGHIST) {
             for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceoffset[1] + j;
+                d4start[0] = global_param.forceskip[1] + global_param.forceoffset[1] + j;
                 for (v = 0; v < options.NVEGTYPES; v++) {
                     d4start[1] = v;
                     get_scatter_nc_field_double(filenames.forcing[1], "fcov",
@@ -302,7 +302,7 @@ vic_force(void)
         // Albedo: alb
         if (options.ALB_SRC == FROM_VEGHIST) {
             for (j = 0; j < NF; j++) {
-                d4start[0] = global_param.forceoffset[1] + j;
+                d4start[0] = global_param.forceskip[1] + global_param.forceoffset[1] + j;
                 for (v = 0; v < options.NVEGTYPES; v++) {
                     d4start[1] = v;
                     get_scatter_nc_field_double(filenames.forcing[1], "alb",
@@ -458,7 +458,7 @@ get_forcing_file_info(param_set_struct *param_set,
     parse_nc_time_units(nc_unit_chars, &time_units, &nc_origin_dmy);
 
     // Get date/time of the first entry in the forcing file.
-    nc_time_origin = date2num(0., &nc_origin_dmy, 0., calendar, time_units);
+    nc_time_origin = date2num(0., &nc_origin_dmy, 0., calendar, TIME_UNITS_DAYS);
     num2date(nc_time_origin, nc_times[0], 0., calendar, time_units,
              &nc_start_dmy);
 

--- a/vic/drivers/shared_all/src/compute_derived_state_vars.c
+++ b/vic/drivers/shared_all/src/compute_derived_state_vars.c
@@ -109,11 +109,9 @@ compute_derived_state_vars(all_vars_struct *all_vars,
         }
     }
 
-
     /******************************************
        Compute soil thermal node properties
     ******************************************/
-
     FIRST_VEG = true;
     for (veg = 0; veg <= Nveg; veg++) {
         // Initialize soil for existing vegetation types

--- a/vic/drivers/shared_all/src/compute_derived_state_vars.c
+++ b/vic/drivers/shared_all/src/compute_derived_state_vars.c
@@ -57,9 +57,11 @@ compute_derived_state_vars(all_vars_struct *all_vars,
 
     cell_data_struct         **cell;
     energy_bal_struct        **energy;
+    snow_data_struct         **snow;
 
     cell = all_vars->cell;
     energy = all_vars->energy;
+    snow = all_vars->snow;
     Nveg = veg_con[0].vegetat_type_num;
 
     /******************************************
@@ -94,6 +96,19 @@ compute_derived_state_vars(all_vars_struct *all_vars,
             }
         }
     }
+
+    /******************************************
+       Compute derived soil snow state vars
+    ******************************************/
+    for (veg = 0; veg <= Nveg; veg++) {
+        for (band = 0; band < options.SNOW_BAND; band++) {
+            if (snow[veg][band].density > 0.) {
+                snow[veg][band].depth = MM_PER_M * snow[veg][band].swq /
+                                        snow[veg][band].density;
+            }
+        }
+    }
+
 
     /******************************************
        Compute soil thermal node properties

--- a/vic/drivers/shared_image/src/vic_restore.c
+++ b/vic/drivers/shared_image/src/vic_restore.c
@@ -486,6 +486,23 @@ vic_restore(void)
         }
     }
 
+    // Foliage temperature: energy[veg][band].Tfoliage
+    for (m = 0; m < options.NVEGTYPES; m++) {
+        d4start[0] = m;
+        for (k = 0; k < options.SNOW_BAND; k++) {
+            d4start[1] = k;
+            get_scatter_nc_field_double(filenames.init_state,
+                                        "Foliage_temperature",
+                                        d4start, d4count, dvar);
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                v = veg_con_map[i].vidx[m];
+                if (v >= 0) {
+                    all_vars[i].energy[v][k].Tfoliage = dvar[i];
+                }
+            }
+        }
+    }
+
     if (options.LAKES) {
         // total soil moisture
         for (j = 0; j < options.Nlayer; j++) {

--- a/vic/drivers/shared_image/src/vic_restore.c
+++ b/vic/drivers/shared_image/src/vic_restore.c
@@ -503,6 +503,42 @@ vic_restore(void)
         }
     }
 
+    // Outgoing longwave from understory: energy[veg][band].LongUnderOut
+    // This is a flux. Saving it to state file is a temporary solution!!
+    for (m = 0; m < options.NVEGTYPES; m++) {
+        d4start[0] = m;
+        for (k = 0; k < options.SNOW_BAND; k++) {
+            d4start[1] = k;
+            get_scatter_nc_field_double(filenames.init_state,
+                                        "Energy_LongUnderOut",
+                                        d4start, d4count, dvar);
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                v = veg_con_map[i].vidx[m];
+                if (v >= 0) {
+                    all_vars[i].energy[v][k].LongUnderOut = dvar[i];
+                }
+            }
+        }
+    }
+
+    // Thermal flux through the snow pack: energy[veg][band].snow_flux
+    // This is a flux. Saving it to state file is a temporary solution!!
+    for (m = 0; m < options.NVEGTYPES; m++) {
+        d4start[0] = m;
+        for (k = 0; k < options.SNOW_BAND; k++) {
+            d4start[1] = k;
+            get_scatter_nc_field_double(filenames.init_state,
+                                        "Energy_snow_flux",
+                                        d4start, d4count, dvar);
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                v = veg_con_map[i].vidx[m];
+                if (v >= 0) {
+                    all_vars[i].energy[v][k].snow_flux = dvar[i];
+                }
+            }
+        }
+    }
+
     if (options.LAKES) {
         // total soil moisture
         for (j = 0; j < options.Nlayer; j++) {

--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -1288,6 +1288,78 @@ vic_store(dmy_struct *dmy_current)
         dimids[i] = -1;
     }
 
+    // Outgoing longwave from understory: energy[veg][band].LongUnderOut
+    // This is a flux, and saving it to state file is a temporary solution!!
+    ndims = 4;
+    dimids[0] = nc_state_file.veg_dimid;
+    dimids[1] = nc_state_file.band_dimid;
+    dimids[2] = nc_state_file.nj_dimid;
+    dimids[3] = nc_state_file.ni_dimid;
+    for (m = 0; m < options.NVEGTYPES; m++) {
+        d4start[0] = m;
+        for (k = 0; k < options.SNOW_BAND; k++) {
+            d4start[1] = k;
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                v = veg_con_map[i].vidx[m];
+                if (v >= 0) {
+                    dvar[i] = (double)
+                              all_vars[i].energy[v][k].LongUnderOut;
+                }
+                else {
+                    dvar[i] = nc_state_file.d_fillvalue;
+                }
+            }
+            gather_put_nc_field_double(nc_state_file.fname,
+                                       &(nc_state_file.open),
+                                       &(nc_state_file.nc_id),
+                                       nc_state_file.d_fillvalue,
+                                       dimids, ndims, "Energy_LongUnderOut",
+                                       d4start, d4count, dvar);
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                dvar[i] = nc_state_file.d_fillvalue;
+            }
+        }
+    }
+    for (i = 0; i < ndims; i++) {
+        dimids[i] = -1;
+    }
+
+    // Thermal flux through the snow pack: energy[veg][band].snow_flux
+    // This is a flux, and saving it to state file is a temporary solution!!
+    ndims = 4;
+    dimids[0] = nc_state_file.veg_dimid;
+    dimids[1] = nc_state_file.band_dimid;
+    dimids[2] = nc_state_file.nj_dimid;
+    dimids[3] = nc_state_file.ni_dimid;
+    for (m = 0; m < options.NVEGTYPES; m++) {
+        d4start[0] = m;
+        for (k = 0; k < options.SNOW_BAND; k++) {
+            d4start[1] = k;
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                v = veg_con_map[i].vidx[m];
+                if (v >= 0) {
+                    dvar[i] = (double)
+                              all_vars[i].energy[v][k].snow_flux;
+                }
+                else {
+                    dvar[i] = nc_state_file.d_fillvalue;
+                }
+            }
+            gather_put_nc_field_double(nc_state_file.fname,
+                                       &(nc_state_file.open),
+                                       &(nc_state_file.nc_id),
+                                       nc_state_file.d_fillvalue,
+                                       dimids, ndims, "Energy_snow_flux",
+                                       d4start, d4count, dvar);
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                dvar[i] = nc_state_file.d_fillvalue;
+            }
+        }
+    }
+    for (i = 0; i < ndims; i++) {
+        dimids[i] = -1;
+    }
+
     if (options.LAKES) {
         // total soil moisture
         ndims = 3;

--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -1253,6 +1253,41 @@ vic_store(dmy_struct *dmy_current)
         dimids[i] = -1;
     }
 
+    // Foliage temperature: energy[veg][band].Tfoliage
+    ndims = 4;
+    dimids[0] = nc_state_file.veg_dimid;
+    dimids[1] = nc_state_file.band_dimid;
+    dimids[2] = nc_state_file.nj_dimid;
+    dimids[3] = nc_state_file.ni_dimid;
+    for (m = 0; m < options.NVEGTYPES; m++) {
+        d4start[0] = m;
+        for (k = 0; k < options.SNOW_BAND; k++) {
+            d4start[1] = k;
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                v = veg_con_map[i].vidx[m];
+                if (v >= 0) {
+                    dvar[i] = (double)
+                              all_vars[i].energy[v][k].Tfoliage;
+                }
+                else {
+                    dvar[i] = nc_state_file.d_fillvalue;
+                }
+            }
+            gather_put_nc_field_double(nc_state_file.fname,
+                                       &(nc_state_file.open),
+                                       &(nc_state_file.nc_id),
+                                       nc_state_file.d_fillvalue,
+                                       dimids, ndims, "Foliage_temperature",
+                                       d4start, d4count, dvar);
+            for (i = 0; i < local_domain.ncells_active; i++) {
+                dvar[i] = nc_state_file.d_fillvalue;
+            }
+        }
+    }
+    for (i = 0; i < ndims; i++) {
+        dimids[i] = -1;
+    }
+
     if (options.LAKES) {
         // total soil moisture
         ndims = 3;


### PR DESCRIPTION
This PR assured exact restarts for classic and image driver under simple options (more thorough tests to be done). Specifically:
- Made sure the image driver is doing the same computation as classic driver regarding restarting
- For both drivers, `energy->LongUnderOut` and `energy->snow_flux` are now saved to state file. This is a temporary solution to solving the main points in issue #479 and assuring exact restart.