### PR TITLE
Open-mp threading

### DIFF
--- a/vic/drivers/image/Makefile
+++ b/vic/drivers/image/Makefile
@@ -92,7 +92,7 @@ INCLUDES = -I ${DRIVERPATH}/include \
 		   -I ${NETCDFPATH}/include \
 
 # Uncomment to include debugging information
-CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra -std=c99 -DLOG_LVL=$(LOG_LVL)
+CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra -std=c99 -fopenmp -DLOG_LVL=$(LOG_LVL)
 LIBRARY = -lm -L${NETCDFPATH}/lib -lnetcdf
 
 COMPEXE = vic_image

--- a/vic/drivers/shared_image/include/vic_mpi.h
+++ b/vic/drivers/shared_image/include/vic_mpi.h
@@ -29,6 +29,7 @@
 
 #include <vic_def.h>
 #include <mpi.h>
+#include <omp.h>
 #include <stdbool.h>
 
 void create_MPI_filenames_struct_type(MPI_Datatype *mpi_type);

--- a/vic/drivers/shared_image/src/vic_image_run.c
+++ b/vic/drivers/shared_image/src/vic_image_run.c
@@ -52,6 +52,7 @@ vic_image_run(dmy_struct *dmy_current)
     sprint_dmy(dmy_str, dmy_current);
     debug("Running timestep %zu: %s", current, dmy_str);
 
+    #pragma omp parallel for private(i,vic_run_ref_str)
     for (i = 0; i < local_domain.ncells_active; i++) {
         // Set global reference string (for debugging inside vic_run)
         sprintf(vic_run_ref_str, "Gridcell io_idx: %zu, timestep info: %s",


### PR DESCRIPTION
The current VIC MPI approach does not utilize threading for shared-memory on-node calculations. This might be expected to cause performance slow downs coming from a large number of MPI calls.  This PR is introduces `openmp` threading to the `vic_image_run` loop over `local_domain.ncells_active` as proof of concept.  