### PR TITLE
copyright and build info updates

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -17,7 +17,7 @@ For VIC 5 and later, type `vic _{classic,image}.exe -v`
 
 ## VIC 5.0.0 (Release Candidate 1)
 
-**Release date: June 10, 2016**
+**Release date: June 17, 2016**
 
 This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly identical physics as VIC 4.2 while providing a clean, refactored code base supporting multiple drivers. There are a number of new features, bug fixes, and backward incompatible changes. See the VIC Github page for more details on the changes included in this release.
 

--- a/vic/drivers/cesm/Makefile
+++ b/vic/drivers/cesm/Makefile
@@ -7,7 +7,7 @@
  # @section LICENSE
  #
  # The Variable Infiltration Capacity (VIC) macroscale hydrological model
- # Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ # Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  # and Environmental Engineering, University of Washington.
  #
  # The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/Makefile
+++ b/vic/drivers/cesm/Makefile
@@ -73,6 +73,9 @@ else
 FC = mpifort
 endif
 
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+HOSTNAME := $(shell uname -n)
+
 # set includes
 INCLUDES = -I ${DRIVERPATH}/include \
 		   -I ${VICPATH}/include \
@@ -84,7 +87,11 @@ INCLUDES = -I ${DRIVERPATH}/include \
 LIBRARY = -lm -L${NETCDFPATH}/lib -lnetcdf
 
 # Set compiler flags
-CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra -fPIC
+CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra -fPIC \
+					 -DLOG_LVL=$(LOG_LVL) \
+					 -DGIT_VERSION=\"$(GIT_VERSION)\" \
+					 -DUSERNAME=\"$(USER)\" \
+					 -DHOSTNAME=\"$(HOSTNAME)\"
 FFLAGS  = ${INCLUDES} -fPIC
 
 # Set the log level

--- a/vic/drivers/cesm/include/vic_driver_cesm.h
+++ b/vic/drivers/cesm/include/vic_driver_cesm.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/cesm_def_mod_f.F90
+++ b/vic/drivers/cesm/src/cesm_def_mod_f.F90
@@ -7,7 +7,7 @@
 !! @section LICENSE
 !!
 !! The Variable Infiltration Capacity (VIC) macroscale hydrological model
-!! Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+!! Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 !! and Environmental Engineering, University of Washington.
 !!
 !! The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/cesm_interface_f.F90
+++ b/vic/drivers/cesm/src/cesm_interface_f.F90
@@ -6,7 +6,7 @@
 !! @section LICENSE
 !!
 !! The Variable Infiltration Capacity (VIC) macroscale hydrological model
-!! Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+!! Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 !! and Environmental Engineering, University of Washington.
 !!
 !! The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/cesm_mpi_utils.c
+++ b/vic/drivers/cesm/src/cesm_mpi_utils.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/cesm_print_library_f.F90
+++ b/vic/drivers/cesm/src/cesm_print_library_f.F90
@@ -6,7 +6,7 @@
 !! @section LICENSE
 !!
 !! The Variable Infiltration Capacity (VIC) macroscale hydrological model
-!! Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+!! Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 !! and Environmental Engineering, University of Washington.
 !!
 !! The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -9,7 +9,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/display_current_settings.c
+++ b/vic/drivers/cesm/src/display_current_settings.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/print_library_cesm.c
+++ b/vic/drivers/cesm/src/print_library_cesm.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/vic_cesm_alloc.c
+++ b/vic/drivers/cesm/src/vic_cesm_alloc.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/vic_cesm_finalize.c
+++ b/vic/drivers/cesm/src/vic_cesm_finalize.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/vic_cesm_init_library.c
+++ b/vic/drivers/cesm/src/vic_cesm_init_library.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/vic_cesm_start.c
+++ b/vic/drivers/cesm/src/vic_cesm_start.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/vic_cesm_time.c
+++ b/vic/drivers/cesm/src/vic_cesm_time.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/vic_force.c
+++ b/vic/drivers/cesm/src/vic_force.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/cesm/src/vic_populate_model_state.c
+++ b/vic/drivers/cesm/src/vic_populate_model_state.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/Makefile
+++ b/vic/drivers/classic/Makefile
@@ -45,6 +45,9 @@ ifndef CC
 CC=gcc
 endif
 
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+HOSTNAME := $(shell uname -n)
+
 # Set the log level
 # To turn off warning statements, set LOG_LVL >= 30
 # | Level     | Numeric value    |
@@ -63,7 +66,11 @@ INCLUDES = -I ${DRIVERPATH}/include -I $(SHAREDPATH)/include -I ${VICPATH}/inclu
 # LIBRARY = -lm
 
 # Uncomment to include debugging information
-CFLAGS  =  ${INCLUDES} -g -Wall -Wextra -std=c99 -DLOG_LVL=$(LOG_LVL)
+CFLAGS  =  ${INCLUDES} -g -Wall -Wextra -std=c99 \
+					 -DLOG_LVL=$(LOG_LVL) \
+					 -DGIT_VERSION=\"$(GIT_VERSION)\" \
+					 -DUSERNAME=\"$(USER)\" \
+					 -DHOSTNAME=\"$(HOSTNAME)\"
 LIBRARY = -lm
 
 # Uncomment to include execution profiling information

--- a/vic/drivers/classic/Makefile
+++ b/vic/drivers/classic/Makefile
@@ -6,7 +6,7 @@
  # @section LICENSE
  #
  # The Variable Infiltration Capacity (VIC) macroscale hydrological model
- # Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ # Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  # and Environmental Engineering, University of Washington.
  #
  # The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/include/vic_driver_classic.h
+++ b/vic/drivers/classic/include/vic_driver_classic.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/alloc_atmos.c
+++ b/vic/drivers/classic/src/alloc_atmos.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/alloc_veg_hist.c
+++ b/vic/drivers/classic/src/alloc_veg_hist.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/check_files.c
+++ b/vic/drivers/classic/src/check_files.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/check_save_state_flag.c
+++ b/vic/drivers/classic/src/check_save_state_flag.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/check_state_file.c
+++ b/vic/drivers/classic/src/check_state_file.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/close_files.c
+++ b/vic/drivers/classic/src/close_files.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/compute_cell_area.c
+++ b/vic/drivers/classic/src/compute_cell_area.c
@@ -6,7 +6,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/display_current_settings.c
+++ b/vic/drivers/classic/src/display_current_settings.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/free_out_data_files.c
+++ b/vic/drivers/classic/src/free_out_data_files.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/get_dist.c
+++ b/vic/drivers/classic/src/get_dist.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/get_force_type.c
+++ b/vic/drivers/classic/src/get_force_type.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/get_global_param.c
+++ b/vic/drivers/classic/src/get_global_param.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/initialize_forcing_files.c
+++ b/vic/drivers/classic/src/initialize_forcing_files.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/make_in_and_outfiles.c
+++ b/vic/drivers/classic/src/make_in_and_outfiles.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/open_state_file.c
+++ b/vic/drivers/classic/src/open_state_file.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/parse_output_info.c
+++ b/vic/drivers/classic/src/parse_output_info.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/print_library_classic.c
+++ b/vic/drivers/classic/src/print_library_classic.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_atmos_data.c
+++ b/vic/drivers/classic/src/read_atmos_data.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_forcing_data.c
+++ b/vic/drivers/classic/src/read_forcing_data.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_initial_model_state.c
+++ b/vic/drivers/classic/src/read_initial_model_state.c
@@ -12,7 +12,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_lakeparam.c
+++ b/vic/drivers/classic/src/read_lakeparam.c
@@ -9,7 +9,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_snowband.c
+++ b/vic/drivers/classic/src/read_snowband.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_soilparam.c
+++ b/vic/drivers/classic/src/read_soilparam.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_veglib.c
+++ b/vic/drivers/classic/src/read_veglib.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/read_vegparam.c
+++ b/vic/drivers/classic/src/read_vegparam.c
@@ -9,7 +9,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/set_output_defaults.c
+++ b/vic/drivers/classic/src/set_output_defaults.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/vic_classic.c
+++ b/vic/drivers/classic/src/vic_classic.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/vic_force.c
+++ b/vic/drivers/classic/src/vic_force.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/vic_populate_model_state.c
+++ b/vic/drivers/classic/src/vic_populate_model_state.c
@@ -14,7 +14,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/write_data.c
+++ b/vic/drivers/classic/src/write_data.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/write_forcing_file.c
+++ b/vic/drivers/classic/src/write_forcing_file.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/write_header.c
+++ b/vic/drivers/classic/src/write_header.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/write_model_state.c
+++ b/vic/drivers/classic/src/write_model_state.c
@@ -14,7 +14,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/classic/src/write_output.c
+++ b/vic/drivers/classic/src/write_output.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/Makefile
+++ b/vic/drivers/image/Makefile
@@ -74,6 +74,9 @@ else
 CC = mpicc
 endif
 
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always --tags)
+HOSTNAME := $(shell uname -n)
+
 # Set the log level
 # To turn off warning statements, set LOG_LVL >= 30
 # | Level     | Numeric value    |
@@ -92,7 +95,11 @@ INCLUDES = -I ${DRIVERPATH}/include \
 		   -I ${NETCDFPATH}/include \
 
 # Uncomment to include debugging information
-CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra -std=c99 -DLOG_LVL=$(LOG_LVL)
+CFLAGS  =  ${INCLUDES} -ggdb -O0 -Wall -Wextra -std=c99 \
+					 -DLOG_LVL=$(LOG_LVL) \
+					 -DGIT_VERSION=\"$(GIT_VERSION)\" \
+					 -DUSERNAME=\"$(USER)\" \
+					 -DHOSTNAME=\"$(HOSTNAME)\"
 LIBRARY = -lm -L${NETCDFPATH}/lib -lnetcdf
 
 COMPEXE = vic_image

--- a/vic/drivers/image/Makefile
+++ b/vic/drivers/image/Makefile
@@ -6,7 +6,7 @@
  # @section LICENSE
  #
  # The Variable Infiltration Capacity (VIC) macroscale hydrological model
- # Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ # Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  # and Environmental Engineering, University of Washington.
  #
  # The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/check_save_state_flag.c
+++ b/vic/drivers/image/src/check_save_state_flag.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/display_current_settings.c
+++ b/vic/drivers/image/src/display_current_settings.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/get_global_param.c
+++ b/vic/drivers/image/src/get_global_param.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/vic_image_finalize.c
+++ b/vic/drivers/image/src/vic_image_finalize.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/vic_image_init.c
+++ b/vic/drivers/image/src/vic_image_init.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/vic_image_start.c
+++ b/vic/drivers/image/src/vic_image_start.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/image/src/vic_populate_model_state.c
+++ b/vic/drivers/image/src/vic_populate_model_state.c
@@ -12,7 +12,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/python/include/vic_driver_python.h
+++ b/vic/drivers/python/include/vic_driver_python.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/python/src/display_current_settings.c
+++ b/vic/drivers/python/src/display_current_settings.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/python/src/globals.c
+++ b/vic/drivers/python/src/globals.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/python/vic/driver.py
+++ b/vic/drivers/python/vic/driver.py
@@ -6,7 +6,7 @@
   @section LICENSE
 
   The Variable Infiltration Capacity (VIC) macroscale hydrological model
-  Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+  Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
   and Environmental Engineering, University of Washington.
 
   The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/python/vic/vic.py
+++ b/vic/drivers/python/vic/vic.py
@@ -6,7 +6,7 @@
   @section LICENSE
 
   The Variable Infiltration Capacity (VIC) macroscale hydrological model
-  Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+  Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
   and Environmental Engineering, University of Washington.
 
   The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/include/vic_driver_shared_all.h
+++ b/vic/drivers/shared_all/include/vic_driver_shared_all.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/include/vic_driver_shared_all.h
+++ b/vic/drivers/shared_all/include/vic_driver_shared_all.h
@@ -28,9 +28,7 @@
 #define VIC_DRIVER_SHARED_H
 
 #include <vic_run.h>
-
-#define VERSION "5.0.0 candidate 1: June 10, 2016"
-#define SHORT_VERSION "5.0.0 candidate 1"
+#include <vic_version.h>
 
 /******************************************************************************
  * @brief   Met file formats

--- a/vic/drivers/shared_all/include/vic_version.h
+++ b/vic/drivers/shared_all/include/vic_version.h
@@ -1,0 +1,108 @@
+/******************************************************************************
+ * @section DESCRIPTION
+ *
+ * Header file for build time metadata
+ *
+ * @section LICENSE
+ *
+ * The Variable Infiltration Capacity (VIC) macroscale hydrological model
+ * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * and Environmental Engineering, University of Washington.
+ *
+ * The VIC model is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *****************************************************************************/
+
+#ifndef VIC_VERSION_H
+#define VIC_VERSION_H
+
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+
+#ifndef VERSION
+#define VERSION "5.0.0 Release Candidate 1: June 17, 2016"
+#endif
+
+#ifndef SHORT_VERSION
+#define SHORT_VERSION "5.0.0.rc1"
+#endif
+
+#ifndef GIT_VERSION
+#define GIT_VERSION "unset"
+#endif
+
+#ifndef USERNAME
+#define USERNAME "unset"
+#endif
+
+#ifndef HOSTNAME
+#define HOSTNAME "unset"
+#endif
+
+#define BUILD_DATE __DATE__
+#define BUILD_TIME __TIME__
+
+/* Get compiler metadata */
+#if defined(__clang__)
+/* Clang/LLVM. ---------------------------------------------- */
+# define COMPILER "clang"
+# define COMPILER_VERSION __clang_version__
+
+#elif defined(__ICC) || defined(__INTEL_COMPILER)
+/* Intel ICC/ICPC. ------------------------------------------ */
+# define COMPILER "icc"
+# define COMPILER_VERSION __version__
+
+#elif defined(__GNUC__) || defined(__GNUG__)
+/* GNU GCC/G++. --------------------------------------------- */
+# define COMPILER "gcc"
+# define COMPILER_VERSION STR(__GNUC__) "." STR(__GNUC_MINOR__) "." STR(__GNUC_PATCHLEVEL__)
+
+#elif defined(__PGI)
+/* Portland Group PGCC/PGCPP. ------------------------------- */
+# define COMPILER "pgcc"
+# define COMPILER_VERSION __PGIC__ __PGIC_MINOR __PGIC_PATCHLEVEL__
+
+#elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+/* Oracle Solaris Studio. ----------------------------------- */
+# define COMPILER "pgcc"
+# define COMPILER_VERSION __PGIC__ __PGIC_MINOR __PGIC_PATCHLEVEL__
+#endif
+#ifndef COMPILER
+# define COMPILER "unknown"
+# define COMPILER_VERSION "unknown"
+#endif
+
+/* C Standard */
+#ifdef __STDC_VERSION__
+# define CSTANDARD __STDC_VERSION__
+#endif
+#ifndef CSTANDARD
+# define CSTANDARD "unknown"
+#endif
+
+/* Platform */
+
+#ifdef __APPLE__
+# define PLATFORM "APPLE"
+#elif __linux__
+# define PLATFORM "LINUX"
+#elif __unix__ // all unices, not all compilers
+# define PLATFORM "UNIX"
+#endif
+#ifndef PLATFORM
+# define PLATFORM "unknown"
+#endif
+
+#endif

--- a/vic/drivers/shared_all/src/calc_root_fraction.c
+++ b/vic/drivers/shared_all/src/calc_root_fraction.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/cmd_proc.c
+++ b/vic/drivers/shared_all/src/cmd_proc.c
@@ -131,10 +131,10 @@ print_license()
     fprintf(stdout,
             "\n  Variable Infiltration Capacity (VIC) macroscale hydrologic\n");
     fprintf(stdout,
-            "  model version %s, Copyright (C) 2014 Land Surface\n",
+            "  model version %s, Copyright (C) 2016 Computational Hydrology\n",
             SHORT_VERSION);
     fprintf(stdout,
-            "  Hydrology Group, Dept. of Civil and Environmental Engineering,\n");
+            "  Group, Dept. of Civil and Environmental Engineering,\n");
     fprintf(stdout,
             "  University of Washington.  VIC comes with ABSOLUTELY NO\n");
     fprintf(stdout,

--- a/vic/drivers/shared_all/src/cmd_proc.c
+++ b/vic/drivers/shared_all/src/cmd_proc.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/cmd_proc.c
+++ b/vic/drivers/shared_all/src/cmd_proc.c
@@ -116,8 +116,13 @@ print_usage(char *executable)
 void
 print_version(char *driver)
 {
-    fprintf(stdout, "  VIC Version : %s\n", SHORT_VERSION);
-    fprintf(stdout, "  VIC Driver  : %s\n", driver);
+    fprintf(stdout, "VIC Driver  : %s\n", driver);
+    fprintf(stdout, "VIC Version : %s\n", VERSION);
+    fprintf(stdout, "VIC Git Tag : %s\n", GIT_VERSION);
+    fprintf(stdout, "Compiled    : by %s on %s (%s) %s %s\n",
+            USERNAME, HOSTNAME, PLATFORM, BUILD_DATE, BUILD_TIME);
+    fprintf(stdout, "Compiler    : %s\n", COMPILER);
+    fprintf(stdout, " version    : %s\n", COMPILER_VERSION);
 
     print_license();
 }

--- a/vic/drivers/shared_all/src/compress_files.c
+++ b/vic/drivers/shared_all/src/compress_files.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/compute_derived_state_vars.c
+++ b/vic/drivers/shared_all/src/compute_derived_state_vars.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/compute_lake_params.c
+++ b/vic/drivers/shared_all/src/compute_lake_params.c
@@ -7,7 +7,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/compute_treeline.c
+++ b/vic/drivers/shared_all/src/compute_treeline.c
@@ -17,7 +17,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/forcing_utils.c
+++ b/vic/drivers/shared_all/src/forcing_utils.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/free_all_vars.c
+++ b/vic/drivers/shared_all/src/free_all_vars.c
@@ -9,7 +9,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/free_vegcon.c
+++ b/vic/drivers/shared_all/src/free_vegcon.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/generate_default_lake_state.c
+++ b/vic/drivers/shared_all/src/generate_default_lake_state.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/get_parameters.c
+++ b/vic/drivers/shared_all/src/get_parameters.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_energy.c
+++ b/vic/drivers/shared_all/src/initialize_energy.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_files.c
+++ b/vic/drivers/shared_all/src/initialize_files.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_global.c
+++ b/vic/drivers/shared_all/src/initialize_global.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_options.c
+++ b/vic/drivers/shared_all/src/initialize_options.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_parameters.c
+++ b/vic/drivers/shared_all/src/initialize_parameters.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_snow.c
+++ b/vic/drivers/shared_all/src/initialize_snow.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_soil.c
+++ b/vic/drivers/shared_all/src/initialize_soil.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/initialize_veg.c
+++ b/vic/drivers/shared_all/src/initialize_veg.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/make_all_vars.c
+++ b/vic/drivers/shared_all/src/make_all_vars.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/make_cell_data.c
+++ b/vic/drivers/shared_all/src/make_cell_data.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/make_dmy.c
+++ b/vic/drivers/shared_all/src/make_dmy.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/make_energy_bal.c
+++ b/vic/drivers/shared_all/src/make_energy_bal.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/make_snow_data.c
+++ b/vic/drivers/shared_all/src/make_snow_data.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/make_veg_var.c
+++ b/vic/drivers/shared_all/src/make_veg_var.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/open_file.c
+++ b/vic/drivers/shared_all/src/open_file.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/output_list_utils.c
+++ b/vic/drivers/shared_all/src/output_list_utils.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/print_library_shared.c
+++ b/vic/drivers/shared_all/src/print_library_shared.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/put_data.c
+++ b/vic/drivers/shared_all/src/put_data.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/soil_moisture_from_water_table.c
+++ b/vic/drivers/shared_all/src/soil_moisture_from_water_table.c
@@ -40,7 +40,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/update_step_vars.c
+++ b/vic/drivers/shared_all/src/update_step_vars.c
@@ -7,7 +7,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/vic_log.c
+++ b/vic/drivers/shared_all/src/vic_log.c
@@ -10,7 +10,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/vic_time.c
+++ b/vic/drivers/shared_all/src/vic_time.c
@@ -9,7 +9,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_all/src/zero_output_list.c
+++ b/vic/drivers/shared_all/src/zero_output_list.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/include/vic_driver_shared_image.h
+++ b/vic/drivers/shared_image/include/vic_driver_shared_image.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/include/vic_mpi.h
+++ b/vic/drivers/shared_image/include/vic_mpi.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/alloc_atmos.c
+++ b/vic/drivers/shared_image/src/alloc_atmos.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/alloc_veg_hist.c
+++ b/vic/drivers/shared_image/src/alloc_veg_hist.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/get_global_domain.c
+++ b/vic/drivers/shared_image/src/get_global_domain.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/get_nc_dimension.c
+++ b/vic/drivers/shared_image/src/get_nc_dimension.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/get_nc_field.c
+++ b/vic/drivers/shared_image/src/get_nc_field.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/get_nc_var_attr.c
+++ b/vic/drivers/shared_image/src/get_nc_var_attr.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/get_nc_varndimensions.c
+++ b/vic/drivers/shared_image/src/get_nc_varndimensions.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/init_library.c
+++ b/vic/drivers/shared_image/src/init_library.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/parse_output_info.c
+++ b/vic/drivers/shared_image/src/parse_output_info.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/print_library_shared_image.c
+++ b/vic/drivers/shared_image/src/print_library_shared_image.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/put_nc_attr.c
+++ b/vic/drivers/shared_image/src/put_nc_attr.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/put_nc_field.c
+++ b/vic/drivers/shared_image/src/put_nc_field.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/set_force_type.c
+++ b/vic/drivers/shared_image/src/set_force_type.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_alloc.c
+++ b/vic/drivers/shared_image/src/vic_alloc.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_finalize.c
+++ b/vic/drivers/shared_image/src/vic_finalize.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_image_run.c
+++ b/vic/drivers/shared_image/src/vic_image_run.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_init.c
+++ b/vic/drivers/shared_image/src/vic_init.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_init_output.c
+++ b/vic/drivers/shared_image/src/vic_init_output.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_mpi_support.c
+++ b/vic/drivers/shared_image/src/vic_mpi_support.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_nc_info.c
+++ b/vic/drivers/shared_image/src/vic_nc_info.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_restore.c
+++ b/vic/drivers/shared_image/src/vic_restore.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_start.c
+++ b/vic/drivers/shared_image/src/vic_start.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/drivers/shared_image/src/vic_write.c
+++ b/vic/drivers/shared_image/src/vic_write.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/include/vic_def.h
+++ b/vic/vic_run/include/vic_def.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/include/vic_physical_constants.h
+++ b/vic/vic_run/include/vic_physical_constants.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/CalcAerodynamic.c
+++ b/vic/vic_run/src/CalcAerodynamic.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/CalcBlowingSnow.c
+++ b/vic/vic_run/src/CalcBlowingSnow.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/IceEnergyBalance.c
+++ b/vic/vic_run/src/IceEnergyBalance.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/SnowPackEnergyBalance.c
+++ b/vic/vic_run/src/SnowPackEnergyBalance.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/StabilityCorrection.c
+++ b/vic/vic_run/src/StabilityCorrection.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/advected_sensible_heat.c
+++ b/vic/vic_run/src/advected_sensible_heat.c
@@ -11,7 +11,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/alloc_and_free.c
+++ b/vic/vic_run/src/alloc_and_free.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/arno_evap.c
+++ b/vic/vic_run/src/arno_evap.c
@@ -12,7 +12,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/calc_Nscale_factors.c
+++ b/vic/vic_run/src/calc_Nscale_factors.c
@@ -10,7 +10,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/calc_atmos_energy_bal.c
+++ b/vic/vic_run/src/calc_atmos_energy_bal.c
@@ -11,7 +11,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/calc_rainonly.c
+++ b/vic/vic_run/src/calc_rainonly.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/calc_snow_coverage.c
+++ b/vic/vic_run/src/calc_snow_coverage.c
@@ -12,7 +12,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/calc_surf_energy_bal.c
+++ b/vic/vic_run/src/calc_surf_energy_bal.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/calc_veg_params.c
+++ b/vic/vic_run/src/calc_veg_params.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/canopy_assimilation.c
+++ b/vic/vic_run/src/canopy_assimilation.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/canopy_evap.c
+++ b/vic/vic_run/src/canopy_evap.c
@@ -10,7 +10,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/comparisons.c
+++ b/vic/vic_run/src/comparisons.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/compute_coszen.c
+++ b/vic/vic_run/src/compute_coszen.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/compute_derived_lake_dimensions.c
+++ b/vic/vic_run/src/compute_derived_lake_dimensions.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/compute_pot_evap.c
+++ b/vic/vic_run/src/compute_pot_evap.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/compute_soil_resp.c
+++ b/vic/vic_run/src/compute_soil_resp.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/compute_zwt.c
+++ b/vic/vic_run/src/compute_zwt.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/correct_precip.c
+++ b/vic/vic_run/src/correct_precip.c
@@ -12,7 +12,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/estimate_T1.c
+++ b/vic/vic_run/src/estimate_T1.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/faparl.c
+++ b/vic/vic_run/src/faparl.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/frozen_soil.c
+++ b/vic/vic_run/src/frozen_soil.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/func_atmos_energy_bal.c
+++ b/vic/vic_run/src/func_atmos_energy_bal.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/func_atmos_moist_bal.c
+++ b/vic/vic_run/src/func_atmos_moist_bal.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/func_canopy_energy_bal.c
+++ b/vic/vic_run/src/func_canopy_energy_bal.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/func_surf_energy_bal.c
+++ b/vic/vic_run/src/func_surf_energy_bal.c
@@ -12,7 +12,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/ice_melt.c
+++ b/vic/vic_run/src/ice_melt.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/initialize_lake.c
+++ b/vic/vic_run/src/initialize_lake.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/interpoloation.c
+++ b/vic/vic_run/src/interpoloation.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/lake_utils.c
+++ b/vic/vic_run/src/lake_utils.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/lakes.eb.c
+++ b/vic/vic_run/src/lakes.eb.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/latent_heat_from_snow.c
+++ b/vic/vic_run/src/latent_heat_from_snow.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/massrelease.c
+++ b/vic/vic_run/src/massrelease.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/newt_raph_func_fast.c
+++ b/vic/vic_run/src/newt_raph_func_fast.c
@@ -11,7 +11,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/penman.c
+++ b/vic/vic_run/src/penman.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/photosynth.c
+++ b/vic/vic_run/src/photosynth.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/physics.c
+++ b/vic/vic_run/src/physics.c
@@ -7,7 +7,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/prepare_full_energy.c
+++ b/vic/vic_run/src/prepare_full_energy.c
@@ -8,7 +8,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/root_brent.c
+++ b/vic/vic_run/src/root_brent.c
@@ -6,7 +6,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/runoff.c
+++ b/vic/vic_run/src/runoff.c
@@ -7,7 +7,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/snow_intercept.c
+++ b/vic/vic_run/src/snow_intercept.c
@@ -7,7 +7,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/snow_melt.c
+++ b/vic/vic_run/src/snow_melt.c
@@ -6,7 +6,7 @@
  * @section LICENSE
  *
  * The Variable Infiltration Capacity (VIC) macroscale hydrological model
- * Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+ * Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
  * and Environmental Engineering, University of Washington.
  *
  * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/surface_fluxes.c
+++ b/vic/vic_run/src/surface_fluxes.c
@@ -8,7 +8,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/svp.c
+++ b/vic/vic_run/src/svp.c
@@ -6,7 +6,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or

--- a/vic/vic_run/src/vic_run.c
+++ b/vic/vic_run/src/vic_run.c
@@ -7,7 +7,7 @@
 * @section LICENSE
 *
 * The Variable Infiltration Capacity (VIC) macroscale hydrological model
-* Copyright (C) 2014 The Land Surface Hydrology Group, Department of Civil
+* Copyright (C) 2016 The Computational Hydrology Group, Department of Civil
 * and Environmental Engineering, University of Washington.
 *
 * The VIC model is free software; you can redistribute it and/or


### PR DESCRIPTION
This PR updates the license and the command line build information.

New features on the command line version string:
1.  Makefiles now pass in `git describe` string
2.  prints basic compiler info (future PRs can add compiler flags and library info)

The Copyright statement has been updated throughout to reference the Computational Hydrology Group and the current year.

```
$ ./vic_image.exe -v
VIC Driver  : Image
VIC Version : 5.0.0 Release Candidate 1: June 17, 2016
VIC Git Tag : VIC.4.2.c-1055-g6a94-dirty
Compiled    : by jhamman on joes-air (APPLE) Jun 15 2016 17:13:02
Compiler    : gcc
 version    : 5.3.0

  Variable Infiltration Capacity (VIC) macroscale hydrologic
  model version 5.0.0.rc1, Copyright (C) 2016 Computational Hydrology
  Group, Dept. of Civil and Environmental Engineering,
  University of Washington.  VIC comes with ABSOLUTELY NO
  WARRANTY. This is free software, you may redistribute it
  under certain conditions; see LICENSE.txt for details.

  Report Bugs and Issues to : https://github.com/UW-Hydro/VIC/issues
  VIC Users Email Listserve : vic_users@u.washington.edu 
```