### PR TITLE
Read/write state and rpointer files in CESM driver

### DIFF
--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -102,6 +102,8 @@ vic_cesm_init(vic_clock     *vclock,
 int
 vic_cesm_run(vic_clock *vclock)
 {
+    char state_filename[MAXSTRING];
+
     // reset l2x fields
     initialize_l2x_data();
 
@@ -119,7 +121,8 @@ vic_cesm_run(vic_clock *vclock)
 
     // if save:
     if (vclock->state_flag) {
-        vic_store(&dmy_current);
+        vic_store(&dmy_current, state_filename);
+        write_rpointer_file(state_filename);
     }
 
     // reset x2l fields

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -240,6 +240,16 @@ get_global_param(FILE *gp)
             else if (strcasecmp("LOG_DIR", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", filenames.log_path);
             }
+            else if (strcasecmp("INIT_STATE", optstr) == 0) {
+                sscanf(cmdstr, "%*s %s", flgstr);
+                if (strcasecmp("FALSE", flgstr) == 0) {
+                    options.INIT_STATE = false;
+                }
+                else {
+                    options.INIT_STATE = true;
+                    strcpy(filenames.init_state, flgstr);
+                }
+            }
             // Define state file format
             else if (strcasecmp("STATE_FORMAT", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -77,7 +77,8 @@ int
 main(int    argc,
      char **argv)
 {
-    int status;
+    int  status;
+    char state_filename[MAXSTRING];
 
     // Initialize MPI - note: logging not yet initialized
     status = MPI_Init(&argc, &argv);
@@ -125,7 +126,8 @@ main(int    argc,
 
         // Write state file
         if (check_save_state_flag(current)) {
-            vic_store(&(dmy[current]));
+            vic_store(&(dmy[current]), state_filename);
+            debug("finished storing state file: %s", state_filename)
         }
     }
 

--- a/vic/drivers/shared_image/include/vic_driver_shared_image.h
+++ b/vic/drivers/shared_image/include/vic_driver_shared_image.h
@@ -251,7 +251,7 @@ void vic_init(void);
 void vic_init_output(dmy_struct *dmy_current);
 void vic_restore(void);
 void vic_start(void);
-void vic_store(dmy_struct *dmy_current);
+void vic_store(dmy_struct *dmy_current, char *state_filename);
 void vic_write(stream_struct *stream, nc_file_struct *nc_hist_file,
                dmy_struct *dmy_current);
 void vic_write_output(dmy_struct *dmy);

--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -30,7 +30,8 @@
  * @brief    Save model state.
  *****************************************************************************/
 void
-vic_store(dmy_struct *dmy_current)
+vic_store(dmy_struct *dmy_current,
+          char       *filename)
 {
     extern filenames_struct    filenames;
     extern all_vars_struct    *all_vars;
@@ -39,7 +40,6 @@ vic_store(dmy_struct *dmy_current)
     extern veg_con_map_struct *veg_con_map;
     extern int                 mpi_rank;
 
-    char                       filename[MAXSTRING];
     int                        status;
     int                        v;
     size_t                     i;


### PR DESCRIPTION
This PR completes the statefile loop in the CESM driver.  Previously, the CESM driver was not reading/writing state files using the [rpointer (restart pointer) system](http://www.cesm.ucar.edu/models/cesm1.0/cice/doc/node28.html) and now it is.  

fixes #461 