### PR TITLE
fixed mpi_rank == VIC_MPI_ROOT

### DIFF
--- a/vic/drivers/shared_image/src/vic_finalize.c
+++ b/vic/drivers/shared_image/src/vic_finalize.c
@@ -64,7 +64,7 @@ vic_finalize(void)
     int                        status;
 
 
-    if (mpi_rank == 0) {
+    if (mpi_rank == VIC_MPI_ROOT) {
         // close the global parameter file
         fclose(filep.globalparam);
 


### PR DESCRIPTION
little fix: mpi_rank == 0 to mpi_rank == VIC_MPI_ROOT in vic_finalize.c