### PR TITLE
check_alloc_status

### DIFF
--- a/vic/drivers/shared_image/src/vic_mpi_support.c
+++ b/vic/drivers/shared_image/src/vic_mpi_support.c
@@ -2067,7 +2067,7 @@ get_scatter_nc_field_double(char   *nc_name,
 
         dvar_filtered =
             malloc(global_domain.ncells_active * sizeof(*dvar_filtered));
-        check_alloc_status(dvar, "Memory allocation error.");
+        check_alloc_status(dvar_filtered, "Memory allocation error.");
 
         dvar_mapped =
             malloc(global_domain.ncells_active * sizeof(*dvar_mapped));


### PR DESCRIPTION
`check_alloc_status(dvar` should be `check_alloc_status(dvar_filtered`. fixed now
