### PR TITLE
Fixed bugs related to ice heat capacity

### DIFF
--- a/vic/vic_run/include/vic_physical_constants.h
+++ b/vic/vic_run/include/vic_physical_constants.h
@@ -108,6 +108,8 @@
 #define CONST_CPFW 4.188e3  /**< specific heat of fresh h2o ~ J/kg/K */
 #define CONST_CPFWICE 4.2e3  /**< specific heat of fresh h2o ~ J/kg/K */
 #define CONST_CPICE 2.11727e3  /**< specific heat of fresh ice ~ J/kg/K */
+/**< volumetric heats */
+#define CONST_VCPICE_WQ (CONST_CPICE * CONST_RHOFW)  /**< heat capacity of fresh ice per volume of water equivalent ~ J/m^3/K */
 /**< latent heats */
 #define CONST_LATICE 3.337e5  /**< latent heat of fusion ~ J/kg */
 #define CONST_LATVAP 2.501e6  /**< latent heat of evaporation ~ J/kg */

--- a/vic/vic_run/src/SnowPackEnergyBalance.c
+++ b/vic/vic_run/src/SnowPackEnergyBalance.c
@@ -245,7 +245,7 @@ SnowPackEnergyBalance(double  TSurf,
     }
 
     /* Calculate change in cold content */
-    *DeltaColdContent = CONST_CPICE * CONST_RHOFW * SweSurfaceLayer *
+    *DeltaColdContent = CONST_VCPICE_WQ * SweSurfaceLayer *
                         (TSurf - OldTSurf) / (Dt);
 
     /* Calculate Ground Heat Flux */

--- a/vic/vic_run/src/SnowPackEnergyBalance.c
+++ b/vic/vic_run/src/SnowPackEnergyBalance.c
@@ -245,8 +245,8 @@ SnowPackEnergyBalance(double  TSurf,
     }
 
     /* Calculate change in cold content */
-    *DeltaColdContent = CONST_CPICE * SweSurfaceLayer * (TSurf - OldTSurf) /
-                        (Dt);
+    *DeltaColdContent = CONST_CPICE * CONST_RHOFW * SweSurfaceLayer *
+                        (TSurf - OldTSurf) / (Dt);
 
     /* Calculate Ground Heat Flux */
     if (SnowDepth > 0.) {

--- a/vic/vic_run/src/calc_surf_energy_bal.c
+++ b/vic/vic_run/src/calc_surf_energy_bal.c
@@ -690,7 +690,7 @@ calc_surf_energy_bal(double             Le,
         if (snow->swq > 0) {
             // set snow energy terms
             snow->surf_temp = (Tsurf > 0) ? 0 : Tsurf;
-            snow->coldcontent = CONST_CPICE * CONST_RHOFW * snow->surf_temp *
+            snow->coldcontent = CONST_VCPICE_WQ * snow->surf_temp *
                                 snow->swq;
 
             // recompute snow depth

--- a/vic/vic_run/src/calc_surf_energy_bal.c
+++ b/vic/vic_run/src/calc_surf_energy_bal.c
@@ -690,7 +690,8 @@ calc_surf_energy_bal(double             Le,
         if (snow->swq > 0) {
             // set snow energy terms
             snow->surf_temp = (Tsurf > 0) ? 0 : Tsurf;
-            snow->coldcontent = CONST_CPICE * snow->surf_temp * snow->swq;
+            snow->coldcontent = CONST_CPICE * CONST_RHOFW * snow->surf_temp *
+                                snow->swq;
 
             // recompute snow depth
             old_depth = snow->depth;

--- a/vic/vic_run/src/func_surf_energy_bal.c
+++ b/vic/vic_run/src/func_surf_energy_bal.c
@@ -642,11 +642,11 @@ func_surf_energy_bal(double  Ts,
     /* if thin snowpack, compute the change in energy stored in the pack */
     if (INCLUDE_SNOW) {
         if (TMean > 0.) {
-            *deltaCC = CONST_CPICE *
+            *deltaCC = CONST_CPICE * CONST_RHOFW *
                        (snow_swq - snow_water) * (0. - OldTSurf) / delta_t;
         }
         else {
-            *deltaCC = CONST_CPICE *
+            *deltaCC = CONST_CPICE * CONST_RHOFW *
                        (snow_swq - snow_water) * (TMean - OldTSurf) / delta_t;
         }
         *refreeze_energy = (snow_water * CONST_LATICE * snow_density) / delta_t;

--- a/vic/vic_run/src/func_surf_energy_bal.c
+++ b/vic/vic_run/src/func_surf_energy_bal.c
@@ -642,12 +642,12 @@ func_surf_energy_bal(double  Ts,
     /* if thin snowpack, compute the change in energy stored in the pack */
     if (INCLUDE_SNOW) {
         if (TMean > 0.) {
-            *deltaCC = CONST_CPICE * CONST_RHOFW *
-                       (snow_swq - snow_water) * (0. - OldTSurf) / delta_t;
+            *deltaCC = CONST_VCPICE_WQ * (snow_swq - snow_water) *
+                       (0. - OldTSurf) / delta_t;
         }
         else {
-            *deltaCC = CONST_CPICE * CONST_RHOFW *
-                       (snow_swq - snow_water) * (TMean - OldTSurf) / delta_t;
+            *deltaCC = CONST_VCPICE_WQ * (snow_swq - snow_water) *
+                       (TMean - OldTSurf) / delta_t;
         }
         *refreeze_energy = (snow_water * CONST_LATICE * snow_density) / delta_t;
         *deltaCC *= snow_coverage; // adjust for snow cover fraction

--- a/vic/vic_run/src/ice_melt.c
+++ b/vic/vic_run/src/ice_melt.c
@@ -137,13 +137,13 @@ ice_melt(double            z2,
     }
 
     /* Calculate cold contents */
-    SurfaceCC = CONST_CPICE * CONST_RHOFW * SurfaceSwq * snow->surf_temp;
-    PackCC = CONST_CPICE * CONST_RHOFW * (PackSwq + PackIce) * snow->pack_temp;
+    SurfaceCC = CONST_VCPICE_WQ * SurfaceSwq * snow->surf_temp;
+    PackCC = CONST_VCPICE_WQ * (PackSwq + PackIce) * snow->pack_temp;
     if (air_temp > 0.0) {
         SnowFallCC = 0.0;
     }
     else {
-        SnowFallCC = CONST_CPICE * CONST_RHOFW * SnowFall * air_temp;
+        SnowFallCC = CONST_VCPICE_WQ * SnowFall * air_temp;
     }
 
     /* Distribute fresh snowfall */
@@ -171,14 +171,14 @@ ice_melt(double            z2,
         DeltaPackCC = 0;
     }
     if (SurfaceSwq > 0.0) {
-        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
+        snow->surf_temp = SurfaceCC / (CONST_VCPICE_WQ * SurfaceSwq);
     }
     else {
         snow->surf_temp = 0.0;
     }
     if (PackSwq + PackIce > 0.0) {
         snow->pack_temp = PackCC /
-                          (CONST_CPICE * CONST_RHOFW * (PackSwq + PackIce));
+                          (CONST_VCPICE_WQ * (PackSwq + PackIce));
     }
     else {
         snow->pack_temp = 0.0;
@@ -509,9 +509,9 @@ ice_melt(double            z2,
         if (PackSwq + PackIce > 0.0) {
             PackCC =
                 (PackSwq +
-                 PackIce) * CONST_CPICE * CONST_RHOFW * snow->pack_temp +
+                 PackIce) * CONST_VCPICE_WQ * snow->pack_temp +
                  PackRefreezeEnergy;
-            snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW *
+            snow->pack_temp = PackCC / (CONST_VCPICE_WQ *
                               (PackSwq + PackIce));
             if (snow->pack_temp > 0.) {
                 snow->pack_temp = 0.;
@@ -548,8 +548,8 @@ ice_melt(double            z2,
     /* Update snow properties */
     Ice = PackIce + PackSwq + SurfaceSwq;
     if (Ice > param.SNOW_MAX_SURFACE_SWE) {
-        SurfaceCC = CONST_CPICE * CONST_RHOFW * snow->surf_temp * SurfaceSwq;
-        PackCC = CONST_CPICE * CONST_RHOFW * snow->pack_temp * (PackSwq + PackIce);
+        SurfaceCC = CONST_VCPICE_WQ * snow->surf_temp * SurfaceSwq;
+        PackCC = CONST_VCPICE_WQ * snow->pack_temp * (PackSwq + PackIce);
         if (SurfaceSwq > param.SNOW_MAX_SURFACE_SWE) {
             PackCC += SurfaceCC *
                       (SurfaceSwq - param.SNOW_MAX_SURFACE_SWE) / SurfaceSwq;
@@ -568,9 +568,9 @@ ice_melt(double            z2,
             PackSwq -= param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
             SurfaceSwq += param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
         }
-        snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW *
+        snow->pack_temp = PackCC / (CONST_VCPICE_WQ *
                           (PackSwq + PackIce));
-        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
+        snow->surf_temp = SurfaceCC / (CONST_VCPICE_WQ * SurfaceSwq);
     }
     else {
         PackSwq = 0.0;

--- a/vic/vic_run/src/ice_melt.c
+++ b/vic/vic_run/src/ice_melt.c
@@ -137,13 +137,13 @@ ice_melt(double            z2,
     }
 
     /* Calculate cold contents */
-    SurfaceCC = CONST_CPICE * SurfaceSwq * snow->surf_temp;
-    PackCC = CONST_CPICE * (PackSwq + PackIce) * snow->pack_temp;
+    SurfaceCC = CONST_CPICE * CONST_RHOFW * SurfaceSwq * snow->surf_temp;
+    PackCC = CONST_CPICE * CONST_RHOFW * (PackSwq + PackIce) * snow->pack_temp;
     if (air_temp > 0.0) {
         SnowFallCC = 0.0;
     }
     else {
-        SnowFallCC = CONST_CPICE * SnowFall * air_temp;
+        SnowFallCC = CONST_CPICE * CONST_RHOFW * SnowFall * air_temp;
     }
 
     /* Distribute fresh snowfall */
@@ -171,13 +171,14 @@ ice_melt(double            z2,
         DeltaPackCC = 0;
     }
     if (SurfaceSwq > 0.0) {
-        snow->surf_temp = SurfaceCC / (CONST_CPICE * SurfaceSwq);
+        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
     }
     else {
         snow->surf_temp = 0.0;
     }
     if (PackSwq + PackIce > 0.0) {
-        snow->pack_temp = PackCC / (CONST_CPICE * (PackSwq + PackIce));
+        snow->pack_temp = PackCC /
+                          (CONST_CPICE * CONST_RHOFW * (PackSwq + PackIce));
     }
     else {
         snow->pack_temp = 0.0;
@@ -508,8 +509,10 @@ ice_melt(double            z2,
         if (PackSwq + PackIce > 0.0) {
             PackCC =
                 (PackSwq +
-                 PackIce) * CONST_CPICE * snow->pack_temp + PackRefreezeEnergy;
-            snow->pack_temp = PackCC / (CONST_CPICE * (PackSwq + PackIce));
+                 PackIce) * CONST_CPICE * CONST_RHOFW * snow->pack_temp +
+                 PackRefreezeEnergy;
+            snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW *
+                              (PackSwq + PackIce));
             if (snow->pack_temp > 0.) {
                 snow->pack_temp = 0.;
             }
@@ -545,8 +548,8 @@ ice_melt(double            z2,
     /* Update snow properties */
     Ice = PackIce + PackSwq + SurfaceSwq;
     if (Ice > param.SNOW_MAX_SURFACE_SWE) {
-        SurfaceCC = CONST_CPICE * snow->surf_temp * SurfaceSwq;
-        PackCC = CONST_CPICE * snow->pack_temp * (PackSwq + PackIce);
+        SurfaceCC = CONST_CPICE * CONST_RHOFW * snow->surf_temp * SurfaceSwq;
+        PackCC = CONST_CPICE * CONST_RHOFW * snow->pack_temp * (PackSwq + PackIce);
         if (SurfaceSwq > param.SNOW_MAX_SURFACE_SWE) {
             PackCC += SurfaceCC *
                       (SurfaceSwq - param.SNOW_MAX_SURFACE_SWE) / SurfaceSwq;
@@ -565,8 +568,9 @@ ice_melt(double            z2,
             PackSwq -= param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
             SurfaceSwq += param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
         }
-        snow->pack_temp = PackCC / (CONST_CPICE * (PackSwq + PackIce));
-        snow->surf_temp = SurfaceCC / (CONST_CPICE * SurfaceSwq);
+        snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW *
+                          (PackSwq + PackIce));
+        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
     }
     else {
         PackSwq = 0.0;

--- a/vic/vic_run/src/snow_melt.c
+++ b/vic/vic_run/src/snow_melt.c
@@ -122,13 +122,13 @@ snow_melt(double            Le,
     PackSwq = Ice - SurfaceSwq;
 
     /* Calculate cold contents */
-    SurfaceCC = CONST_CPICE * CONST_RHOFW * SurfaceSwq * snow->surf_temp;
-    PackCC = CONST_CPICE * CONST_RHOFW * PackSwq * snow->pack_temp;
+    SurfaceCC = CONST_VCPICE_WQ * SurfaceSwq * snow->surf_temp;
+    PackCC = CONST_VCPICE_WQ * PackSwq * snow->pack_temp;
     if (air_temp > 0.0) {
         SnowFallCC = 0.0;
     }
     else {
-        SnowFallCC = CONST_CPICE * CONST_RHOFW * SnowFall * air_temp;
+        SnowFallCC = CONST_VCPICE_WQ * SnowFall * air_temp;
     }
 
     /* Distribute fresh snowfall */
@@ -153,13 +153,13 @@ snow_melt(double            Le,
         SurfaceCC += SnowFallCC;
     }
     if (SurfaceSwq > 0.0) {
-        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
+        snow->surf_temp = SurfaceCC / (CONST_VCPICE_WQ * SurfaceSwq);
     }
     else {
         snow->surf_temp = 0.0;
     }
     if (PackSwq > 0.0) {
-        snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW * PackSwq);
+        snow->pack_temp = PackCC / (CONST_VCPICE_WQ * PackSwq);
     }
     else {
         snow->pack_temp = 0.0;
@@ -415,9 +415,9 @@ snow_melt(double            Le,
         Ice += snow->pack_water;
         snow->pack_water = 0.0;
         if (PackSwq > 0.0) {
-            PackCC = PackSwq * CONST_CPICE * CONST_RHOFW * snow->pack_temp +
+            PackCC = PackSwq * CONST_VCPICE_WQ * snow->pack_temp +
                      PackRefreezeEnergy;
-            snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW * PackSwq);
+            snow->pack_temp = PackCC / (CONST_VCPICE_WQ * PackSwq);
             if (snow->pack_temp > 0.) {
                 snow->pack_temp = 0.;
             }
@@ -456,8 +456,8 @@ snow_melt(double            Le,
     Ice = PackSwq + SurfaceSwq;
 
     if (Ice > param.SNOW_MAX_SURFACE_SWE) {
-        SurfaceCC = CONST_CPICE * CONST_RHOFW * snow->surf_temp * SurfaceSwq;
-        PackCC = CONST_CPICE * CONST_RHOFW * snow->pack_temp * PackSwq;
+        SurfaceCC = CONST_VCPICE_WQ * snow->surf_temp * SurfaceSwq;
+        PackCC = CONST_VCPICE_WQ * snow->pack_temp * PackSwq;
         if (SurfaceSwq > param.SNOW_MAX_SURFACE_SWE) {
             PackCC += SurfaceCC *
                       (SurfaceSwq - param.SNOW_MAX_SURFACE_SWE) / SurfaceSwq;
@@ -474,8 +474,8 @@ snow_melt(double            Le,
             PackSwq -= param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
             SurfaceSwq += param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
         }
-        snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW * PackSwq);
-        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
+        snow->pack_temp = PackCC / (CONST_VCPICE_WQ * PackSwq);
+        snow->surf_temp = SurfaceCC / (CONST_VCPICE_WQ * SurfaceSwq);
     }
     else {
         PackSwq = 0.0;

--- a/vic/vic_run/src/snow_melt.c
+++ b/vic/vic_run/src/snow_melt.c
@@ -122,13 +122,13 @@ snow_melt(double            Le,
     PackSwq = Ice - SurfaceSwq;
 
     /* Calculate cold contents */
-    SurfaceCC = CONST_CPFWICE * SurfaceSwq * snow->surf_temp;
-    PackCC = CONST_CPFWICE * PackSwq * snow->pack_temp;
+    SurfaceCC = CONST_CPICE * CONST_RHOFW * SurfaceSwq * snow->surf_temp;
+    PackCC = CONST_CPICE * CONST_RHOFW * PackSwq * snow->pack_temp;
     if (air_temp > 0.0) {
         SnowFallCC = 0.0;
     }
     else {
-        SnowFallCC = CONST_CPFWICE * SnowFall * air_temp;
+        SnowFallCC = CONST_CPICE * CONST_RHOFW * SnowFall * air_temp;
     }
 
     /* Distribute fresh snowfall */
@@ -153,13 +153,13 @@ snow_melt(double            Le,
         SurfaceCC += SnowFallCC;
     }
     if (SurfaceSwq > 0.0) {
-        snow->surf_temp = SurfaceCC / (CONST_CPFWICE * SurfaceSwq);
+        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
     }
     else {
         snow->surf_temp = 0.0;
     }
     if (PackSwq > 0.0) {
-        snow->pack_temp = PackCC / (CONST_CPFWICE * PackSwq);
+        snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW * PackSwq);
     }
     else {
         snow->pack_temp = 0.0;
@@ -415,9 +415,9 @@ snow_melt(double            Le,
         Ice += snow->pack_water;
         snow->pack_water = 0.0;
         if (PackSwq > 0.0) {
-            PackCC = PackSwq * CONST_CPFWICE * snow->pack_temp +
+            PackCC = PackSwq * CONST_CPICE * CONST_RHOFW * snow->pack_temp +
                      PackRefreezeEnergy;
-            snow->pack_temp = PackCC / (CONST_CPFWICE * PackSwq);
+            snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW * PackSwq);
             if (snow->pack_temp > 0.) {
                 snow->pack_temp = 0.;
             }
@@ -456,8 +456,8 @@ snow_melt(double            Le,
     Ice = PackSwq + SurfaceSwq;
 
     if (Ice > param.SNOW_MAX_SURFACE_SWE) {
-        SurfaceCC = CONST_CPFWICE * snow->surf_temp * SurfaceSwq;
-        PackCC = CONST_CPFWICE * snow->pack_temp * PackSwq;
+        SurfaceCC = CONST_CPICE * CONST_RHOFW * snow->surf_temp * SurfaceSwq;
+        PackCC = CONST_CPICE * CONST_RHOFW * snow->pack_temp * PackSwq;
         if (SurfaceSwq > param.SNOW_MAX_SURFACE_SWE) {
             PackCC += SurfaceCC *
                       (SurfaceSwq - param.SNOW_MAX_SURFACE_SWE) / SurfaceSwq;
@@ -474,8 +474,8 @@ snow_melt(double            Le,
             PackSwq -= param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
             SurfaceSwq += param.SNOW_MAX_SURFACE_SWE - SurfaceSwq;
         }
-        snow->pack_temp = PackCC / (CONST_CPFWICE * PackSwq);
-        snow->surf_temp = SurfaceCC / (CONST_CPFWICE * SurfaceSwq);
+        snow->pack_temp = PackCC / (CONST_CPICE * CONST_RHOFW * PackSwq);
+        snow->surf_temp = SurfaceCC / (CONST_CPICE * CONST_RHOFW * SurfaceSwq);
     }
     else {
         PackSwq = 0.0;


### PR DESCRIPTION
- In vic_run code, fixed bugs that confused volumetric heat capacity
      and specific heat capacity related to ice
- We can decide if the value of `CONST_CPICE` (specific heat capacity of ice) is reasonable; but it should not make a huge difference on results 