### PR TITLE
Fixed a bug related to VP - to be consistent with VIC4.2

### DIFF
--- a/vic/drivers/classic/src/vic_force.c
+++ b/vic/drivers/classic/src/vic_force.c
@@ -138,6 +138,10 @@ vic_force(force_data_struct *force,
             force[rec].vp[i] = forcing_data[VP][uidx] * PA_PER_KPA;
             // vapor pressure deficit in Pa
             force[rec].vpd[i] = svp(force[rec].air_temp[i]) - force[rec].vp[i];
+            if (force[rec].vpd[i] < 0) {
+                force[rec].vpd[i] = 0;
+                force[rec].vp[i] = svp(force[rec].air_temp[i]);
+            }
             // air density in kg/m3
             force[rec].density[i] = air_density(force[rec].air_temp[i],
                                                 force[rec].pressure[i]);

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -366,6 +366,10 @@ vic_force(void)
             force[i].vp[j] = q_to_vp(force[i].vp[j], force[i].pressure[j]);
             // vapor pressure deficit in Pa
             force[i].vpd[j] = svp(force[i].air_temp[j]) - force[i].vp[j];
+            if (force[i].vpd[j] < 0) {
+                force[i].vpd[j]  = 0;
+                force[i].vp[j]  = svp(force[i].air_temp[j]);
+            }
             // air density in kg/m3
             force[i].density[j] = air_density(force[i].air_temp[j],
                                               force[i].pressure[j]);


### PR DESCRIPTION
- When calculated VPD < 0, now resets VPD to zero, and VP to calculated saturated vapor pressure (this is consistent with VIC4.2)