### PR TITLE
Fixed bugs related to volumetric heat capacity of water

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -176,6 +176,7 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 	Fixed a bug so that the binary format state file I/O works correctly.
 
 5. Fix for a physical constant (water heat capacity) ([GH#574](https://github.com/UW-Hydro/VIC/pull/574))
+
 	Fixed a bug where volumetric heat capacity of water should be used in `func_canopy_energy_bal` (previously specific heat capacity was used).
 
 ------------------------------

--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -175,6 +175,9 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 
 	Fixed a bug so that the binary format state file I/O works correctly.
 
+5. Fix for a physical constant (water heat capacity)
+	Fixed a bug where volumetric heat capacity of water should be used in `func_canopy_energy_bal` (previously specific heat capacity was used).
+
 ------------------------------
 
 ## VIC 4.2.c [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.35302.svg)](http://dx.doi.org/10.5281/zenodo.35302)

--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -175,7 +175,7 @@ This is a major update from VIC 4. The VIC 5.0.0 release aims to have nearly ide
 
 	Fixed a bug so that the binary format state file I/O works correctly.
 
-5. Fix for a physical constant (water heat capacity)
+5. Fix for a physical constant (water heat capacity) ([GH#574](https://github.com/UW-Hydro/VIC/pull/574))
 	Fixed a bug where volumetric heat capacity of water should be used in `func_canopy_energy_bal` (previously specific heat capacity was used).
 
 ------------------------------

--- a/vic/vic_run/src/IceEnergyBalance.c
+++ b/vic/vic_run/src/IceEnergyBalance.c
@@ -178,7 +178,7 @@ IceEnergyBalance(double  TSurf,
     /* Calculate advected heat flux from rain */
 
     // Temporary fix for lake model.
-    *AdvectedEnergy = (CONST_CPFW * Tair * Rain) / Dt;
+    *AdvectedEnergy = (CONST_CPFW * CONST_RHOFW * Tair * Rain) / Dt;
 
     /* Calculate change in cold content */
     /* No change in cold content in lake model */

--- a/vic/vic_run/src/SnowPackEnergyBalance.c
+++ b/vic/vic_run/src/SnowPackEnergyBalance.c
@@ -238,7 +238,7 @@ SnowPackEnergyBalance(double  TSurf,
        Equation 7.3.12 from H.B.H. for rain falling on melting snowpack */
 
     if (TMean == 0.) {
-        *AdvectedEnergy = (CONST_CPFW * (Tair) * Rain) / (Dt);
+        *AdvectedEnergy = (CONST_CPFW * CONST_RHOFW * (Tair) * Rain) / (Dt);
     }
     else {
         *AdvectedEnergy = 0.;

--- a/vic/vic_run/src/func_canopy_energy_bal.c
+++ b/vic/vic_run/src/func_canopy_energy_bal.c
@@ -256,7 +256,8 @@ func_canopy_energy_bal(double  Tfoliage,
 
     /* Calculate the advected energy */
 
-    *AdvectedEnergy = (CONST_CPFW * Tcanopy * Rainfall) / (delta_t);
+    *AdvectedEnergy = (CONST_CPFW * CONST_RHOFW * Tcanopy * Rainfall) /
+                      (delta_t);
 
     /* Calculate the amount of energy available for refreezing */
 


### PR DESCRIPTION
- Fixed bugs where volumetric heat capacity of water (instead of specific heat) should be used
- **NOTE**: it seems that there is a bug in `VIC4.2` - the hardcoded number `4186.8` here should be volumetric heat of water (which is 4186.8e3):  https://github.com/UW-Hydro/VIC/blob/support/VIC.4.2.d/src/func_canopy_energy_bal.c#L262 . Other places in `VIC4.2` related to volumetric heat of water appear to be correct)