### PR TITLE
Updated vic_force in image driver - now input forcing units are consistent with classic driver

### DIFF
--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -357,10 +357,8 @@ vic_force(void)
     // Convert forcings into what we need and calculate missing ones
     for (i = 0; i < local_domain.ncells_active; i++) {
         for (j = 0; j < NF; j++) {
-            // temperature in Celsius
-            force[i].air_temp[j] -= CONST_TKFRZ;
-            // precipitation in mm/period
-            force[i].prec[j] *= global_param.snow_dt;
+            // pressure in Pa
+            force[i].pressure[j] *= PA_PER_KPA;
             // vapor pressure in Pa
             force[i].vp[j] *= PA_PER_KPA;
             // vapor pressure deficit in Pa


### PR DESCRIPTION
Previously, the two drivers require different sets of units for input forcings, which is confusing. Now, the required forcing units for all the 7 required forcing input variables are consistent.