### PR TITLE
Feature/fix typo in run image driver

### DIFF
--- a/docs/Documentation/Drivers/Image/RunVIC.md
+++ b/docs/Documentation/Drivers/Image/RunVIC.md
@@ -48,7 +48,7 @@ At the command prompt, type:
 
 where `global_parameter_filename` = name of the global parameter file corresponding to your project.
 
-To run VIC image driver using multiple processor, type the following instead:
+To run VIC image driver using multiple processors, type the following instead:
 
 `mpiexec -np n_proc vic_image.exe -g global_parameter_filename.txt`
 


### PR DESCRIPTION
This PR fixes a small typo in the documentation for running the image driver. 