### PR TITLE
remove all instances of ErrorString

### DIFF
--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -224,7 +224,7 @@ void rescale_snow_storage(double, double, snow_data_struct *);
 void rescale_soil_veg_fluxes(double, double, cell_data_struct *,
                              veg_var_struct *);
 void rhoinit(double *, double);
-double root_brent(double, double, char *, double (*Function)(double,
+double root_brent(double, double, double (*Function)(double,
                                                              va_list), ...);
 double rtnewt(double x1, double x2, double xacc, double Ur, double Zr);
 int runoff(cell_data_struct *, energy_bal_struct *, soil_con_struct *, double,

--- a/vic/vic_run/src/calc_atmos_energy_bal.c
+++ b/vic/vic_run/src/calc_atmos_energy_bal.c
@@ -67,7 +67,6 @@ calc_atmos_energy_bal(double    InOverSensible,
     double                   T_lower;
     double                   T_upper;
     double                   Tcanopy;
-    char                     ErrorString[MAXSTRING];
 
     F = 1;
 
@@ -100,7 +99,7 @@ calc_atmos_energy_bal(double    InOverSensible,
         T_upper = (Tair) + param.CANOPY_DT;
 
         // iterate for canopy air temperature
-        Tcanopy = root_brent(T_lower, T_upper, ErrorString,
+        Tcanopy = root_brent(T_lower, T_upper,
                              func_atmos_energy_bal, Ra, Tair, atmos_density,
                              InSensible, SensibleHeat);
 
@@ -117,8 +116,7 @@ calc_atmos_energy_bal(double    InOverSensible,
                                                        NetRadiation, Ra, Tair,
                                                        atmos_density,
                                                        InSensible,
-                                                       SensibleHeat,
-                                                       ErrorString);
+                                                       SensibleHeat);
                 return (ERROR);
             }
         }
@@ -185,7 +183,6 @@ error_print_atmos_energy_bal(double  Tcanopy,
     double  InSensible;
 
     double *SensibleHeat;
-    char   *ErrorString;
 
     // extract variables from va_arg
     LatentHeat = (double)  va_arg(ap, double);
@@ -196,7 +193,6 @@ error_print_atmos_energy_bal(double  Tcanopy,
     InSensible = (double)  va_arg(ap, double);
 
     SensibleHeat = (double *)va_arg(ap, double *);
-    ErrorString = (char *)va_arg(ap, char *);
 
     // print variable values
     log_warn("Failure to converge to a solution in root_brent.\n"
@@ -268,7 +264,6 @@ error_print_atmos_moist_bal(double  VPcanopy,
     double  gamma;
     double  vp;
     double *AtmosLatent;
-    char   *ErrorString;
 
     // extract variables from va_arg
     InLatent = (double)  va_arg(ap, double);
@@ -278,7 +273,6 @@ error_print_atmos_moist_bal(double  VPcanopy,
     gamma = (double)  va_arg(ap, double);
     vp = (double)  va_arg(ap, double);
     AtmosLatent = (double *)va_arg(ap, double *);
-    ErrorString = (char *)  va_arg(ap, char *);
 
     // print variable values
     log_err("VPcanopy = %f\n"

--- a/vic/vic_run/src/calc_surf_energy_bal.c
+++ b/vic/vic_run/src/calc_surf_energy_bal.c
@@ -150,7 +150,6 @@ calc_surf_energy_bal(double             Le,
     double                   TmpNetLongSnow;
     double                   TmpNetShortSnow;
     double                   old_swq, old_depth;
-    char                     ErrorString[MAXSTRING];
 
     /**************************************************
        Set All Variables For Use
@@ -299,7 +298,7 @@ calc_surf_energy_bal(double             Le,
             tmpNnodes = Nnodes;
         }
 
-        Tsurf = root_brent(T_lower, T_upper, ErrorString, func_surf_energy_bal,
+        Tsurf = root_brent(T_lower, T_upper, func_surf_energy_bal,
                            VEG, veg_class, delta_t, Cs1, Cs2, D1, D2,
                            T1_old, T2, Ts_old, energy->T, bubble, dp, expt,
                            ice0, kappa1, kappa2, max_moist, moist, root,
@@ -406,7 +405,7 @@ calc_surf_energy_bal(double             Le,
                                                    &energy->latent_sub,
                                                    &energy->sensible,
                                                    &energy->snow_flux,
-                                                   &energy->error, ErrorString);
+                                                   &energy->error);
                 return (ERROR);
             }
         }
@@ -419,7 +418,7 @@ calc_surf_energy_bal(double             Le,
             tmpNnodes = Nnodes;
             FIRST_SOLN[0] = true;
 
-            Tsurf = root_brent(T_lower, T_upper, ErrorString,
+            Tsurf = root_brent(T_lower, T_upper,
                                func_surf_energy_bal, VEG, veg_class,
                                delta_t, Cs1, Cs2, D1, D2, T1_old, T2, Ts_old,
                                energy->T, bubble, dp, expt, ice0, kappa1,
@@ -534,8 +533,7 @@ calc_surf_energy_bal(double             Le,
                                                        &energy->latent_sub,
                                                        &energy->sensible,
                                                        &energy->snow_flux,
-                                                       &energy->error,
-                                                       ErrorString);
+                                                       &energy->error);
                     return (ERROR);
                 }
             }
@@ -934,8 +932,6 @@ error_print_surf_energy_bal(double  Ts,
     double            *snow_flux;
     double            *store_error;
 
-    char              *ErrorString;
-
     /* Define internal routine variables */
     int                i;
 
@@ -1076,17 +1072,13 @@ error_print_surf_energy_bal(double  Ts,
     snow_flux = (double *) va_arg(ap, double *);
     store_error = (double *) va_arg(ap, double *);
 
-    ErrorString = (char *) va_arg(ap, char *);
-
     /***************
        Main Routine
     ***************/
 
-    fprintf(LOG_DEST, "%s", ErrorString);
-    fprintf(LOG_DEST,
-            "ERROR: calc_surf_energy_bal failed to converge to a solution in "
-            "root_brent.  Variable values will be dumped to the screen, check "
-            "for invalid values.\n");
+    log_warn("calc_surf_energy_bal failed to converge to a solution in "
+             "root_brent.  Variable values will be dumped to the screen, check "
+             "for invalid values.");
 
     /* Print Variables */
     /* general model terms */
@@ -1223,12 +1215,9 @@ error_print_surf_energy_bal(double  Ts,
         }
     }
 
-    fprintf(LOG_DEST,
-            "**********\n**********\n"
-            "Finished writing calc_surf_energy_bal variables.\n"
-            "Try increasing param.SURF_DT to get model to complete cell.\n"
-            "Then check output for instabilities."
-            "\n**********\n**********\n");
+    log_warn("Finished writing calc_surf_energy_bal variables.\n"
+             "Try increasing param.SURF_DT to get model to complete cell.\n"
+             "Then check output for instabilities.");
 
     return (ERROR);
 }

--- a/vic/vic_run/src/frozen_soil.c
+++ b/vic/vic_run/src/frozen_soil.c
@@ -374,7 +374,6 @@ calc_soil_thermal_fluxes(int       Nnodes,
     double                   maxdiff;
     double                   diff;
     double                   oldT;
-    char                     ErrorString[MAXSTRING];
     double                   Tlast[MAX_NODES];
 
     Error = 0;
@@ -419,7 +418,7 @@ calc_soil_thermal_fluxes(int       Nnodes,
             else {
                 T[j] =
                     root_brent(T0[j] - (param.SOIL_DT), T0[j] + (param.SOIL_DT),
-                               ErrorString, soil_thermal_eqn,
+                               soil_thermal_eqn,
                                T[j + 1], T[j - 1], T0[j], moist[j],
                                max_moist[j], bubble[j], expt[j], ice[j],
                                A[j], B[j], C[j], D[j], E[j], EXP_TRANS, j);
@@ -436,7 +435,7 @@ calc_soil_thermal_fluxes(int       Nnodes,
                                               ice[j],
                                               gamma[j - 1], A[j], B[j], C[j],
                                               D[j],
-                                              E[j], ErrorString);
+                                              E[j]);
                         return (ERROR);
                     }
                 }
@@ -471,7 +470,7 @@ calc_soil_thermal_fluxes(int       Nnodes,
             else {
                 T[Nnodes - 1] = root_brent(T0[Nnodes - 1] - param.SOIL_DT,
                                            T0[Nnodes - 1] + param.SOIL_DT,
-                                           ErrorString, soil_thermal_eqn,
+                                           soil_thermal_eqn,
                                            T[Nnodes - 1],
                                            T[Nnodes - 2], T0[Nnodes - 1],
                                            moist[Nnodes - 1],
@@ -494,8 +493,7 @@ calc_soil_thermal_fluxes(int       Nnodes,
                                               bubble[Nnodes - 1],
                                               expt[Nnodes - 1], ice[Nnodes - 1],
                                               gamma[Nnodes - 2],
-                                              A[j], B[j], C[j], D[j], E[j],
-                                              ErrorString);
+                                              A[j], B[j], C[j], D[j], E[j]);
                         return (ERROR);
                     }
                 }
@@ -594,7 +592,6 @@ error_print_solve_T_profile(double  T,
     double C;
     double D;
     double E;
-    char  *ErrorString;
 
     TL = (double) va_arg(ap, double);
     TU = (double) va_arg(ap, double);
@@ -610,12 +607,10 @@ error_print_solve_T_profile(double  T,
     C = (double) va_arg(ap, double);
     D = (double) va_arg(ap, double);
     E = (double) va_arg(ap, double);
-    ErrorString = (char *) va_arg(ap, char *);
 
-    fprintf(LOG_DEST, "%s", ErrorString);
-    fprintf(LOG_DEST, "ERROR: solve_T_profile failed to converge to a solution "
-            "in root_brent.  Variable values will be dumped to the "
-            "screen, check for invalid values.\n");
+    log_warn("solve_T_profile failed to converge to a solution "
+             "in root_brent.  Variable values will be dumped to the "
+             "screen, check for invalid values.");
 
     fprintf(LOG_DEST, "T\t%f\n", T);
     fprintf(LOG_DEST, "TL\t%f\n", TL);
@@ -633,9 +628,9 @@ error_print_solve_T_profile(double  T,
     fprintf(LOG_DEST, "D\t%f\n", D);
     fprintf(LOG_DEST, "E\t%f\n", E);
 
-    fprintf(LOG_DEST, "Finished dumping values for solve_T_profile.\n"
-            "Try increasing SOIL_DT to get model to complete cell.\n"
-            "Then check output for instabilities.\n");
+    log_warn("Finished dumping values for solve_T_profile.\n"
+             "Try increasing SOIL_DT to get model to complete cell.\n"
+             "Then check output for instabilities.");
 
     return(ERROR);
 }

--- a/vic/vic_run/src/ice_melt.c
+++ b/vic/vic_run/src/ice_melt.c
@@ -104,8 +104,6 @@ ice_melt(double            z2,
     double                   Ls;
     double                   melt_energy = 0.;
 
-    char                     ErrorString[MAXSTRING];
-
     SnowFall = snowfall / MM_PER_M; /* convert to m */
     RainFall = rainfall / MM_PER_M; /* convert to m */
     IceMelt = 0.0;
@@ -351,7 +349,6 @@ ice_melt(double            z2,
             snow->surf_temp =
                 root_brent((double) (snow->surf_temp - param.SNOW_DT),
                            (double) (snow->surf_temp + param.SNOW_DT),
-                           ErrorString,
                            IceEnergyBalance, delta_t,
                            aero_resist, aero_resist_used, z2, Z0,
                            wind, net_short, longwave, density,
@@ -391,8 +388,7 @@ ice_melt(double            z2,
                                               param.LAKE_RHOSNOW, surf_atten,
                                               &SnowFlux, &latent_heat,
                                               &latent_heat_sub,
-                                              &sensible_heat, &LWnet,
-                                              ErrorString);
+                                              &sensible_heat, &LWnet);
                     return(ERROR);
                 }
             }
@@ -704,8 +700,6 @@ ErrorPrintIcePackEnergyBalance(double  TSurf,
     double *SensibleHeat;       /* Sensible heat exchange at surface (W/m2) */
     double *LWnet;
 
-    char   *ErrorString;
-
     /* initialize variables */
     Dt = (double) va_arg(ap, double);
     Ra = (double) va_arg(ap, double);
@@ -743,14 +737,11 @@ ErrorPrintIcePackEnergyBalance(double  TSurf,
     LatentHeatSub = (double *) va_arg(ap, double *);
     SensibleHeat = (double *) va_arg(ap, double *);
     LWnet = (double *) va_arg(ap, double *);
-    ErrorString = (char *) va_arg(ap, double *);
 
     /* print variables */
-    fprintf(LOG_DEST, "%s", ErrorString);
-    fprintf(LOG_DEST,
-            "ERROR: ice_melt failed to converge to a solution in root_brent.  "
-            "Variable values will be dumped to the screen, check for invalid "
-            "values.\n");
+    log_warn("ice_melt failed to converge to a solution in root_brent.  "
+             "Variable values will be dumped to the screen, check for invalid "
+             "values.");
 
     fprintf(LOG_DEST, "Dt = %f\n", Dt);
     fprintf(LOG_DEST, "Ra = %f\n", Ra);
@@ -790,10 +781,9 @@ ErrorPrintIcePackEnergyBalance(double  TSurf,
     fprintf(LOG_DEST, "SensibleHeat = %f\n", SensibleHeat[0]);
     fprintf(LOG_DEST, "LWnet = %f\n", *LWnet);
 
-    fprintf(LOG_DEST,
-            "Finished dumping snow_melt variables.\n"
-            "Try increasing SNOW_DT to get model to complete cell.\n"
-            "Then check output for instabilities.\n");
+    log_warn("Finished dumping snow_melt variables.\n"
+             "Try increasing SNOW_DT to get model to complete cell.\n"
+             "Then check output for instabilities.");
 
     return(ERROR);
 }

--- a/vic/vic_run/src/root_brent.c
+++ b/vic/vic_run/src/root_brent.c
@@ -59,7 +59,6 @@
 *
 * @param LowerBound Lower bound for root
 * @param UpperBound Upper bound for root
-* @param ErrorString For storing description of errors (if any)
 * @param Function
 * @param ap Variable arguments
 * @return b
@@ -67,7 +66,6 @@
 double
 root_brent(double LowerBound,
            double UpperBound,
-           char *ErrorString,
            double (*Function)(double Estimate, va_list ap),
            ...)
 {

--- a/vic/vic_run/src/snow_intercept.c
+++ b/vic/vic_run/src/snow_intercept.c
@@ -125,8 +125,6 @@ snow_intercept(double             Dt,
     double                   shortwave; //
     double                   Catm; //
 
-    char                     ErrorString[MAXSTRING];
-
     AirDens = force->density[hidx];
     EactAir = force->vp[hidx];
     Press = force->pressure[hidx];
@@ -339,7 +337,7 @@ snow_intercept(double             Dt,
     }
 
     if (Tupper != MISSING && Tlower != MISSING) {
-        *Tfoliage = root_brent(Tlower, Tupper, ErrorString,
+        *Tfoliage = root_brent(Tlower, Tupper,
                                func_canopy_energy_bal, Dt,
                                soil_con->elevation, soil_con->max_moist,
                                soil_con->Wcr, soil_con->Wpwp,
@@ -393,7 +391,7 @@ snow_intercept(double             Dt,
                                                     &NetRadiation,
                                                     &RefreezeEnergy,
                                                     SensibleHeat,
-                                                    VaporMassFlux, ErrorString);
+                                                    VaporMassFlux);
                 return(ERROR);
             }
         }
@@ -673,7 +671,6 @@ error_print_canopy_energy_bal(double  Tfoliage,
     double              *SensibleHeat;
     double              *VaporMassFlux;
 
-    char                *ErrorString;
     size_t               cidx;
 
     /** Read variables from variable length argument list **/
@@ -743,13 +740,11 @@ error_print_canopy_energy_bal(double  Tfoliage,
     RefreezeEnergy = (double *) va_arg(ap, double *);
     SensibleHeat = (double *) va_arg(ap, double *);
     VaporMassFlux = (double *) va_arg(ap, double *);
-    ErrorString = (char *) va_arg(ap, char *);
 
     /** Print variable info */
-    fprintf(LOG_DEST, "%s", ErrorString);
-    fprintf(LOG_DEST, "ERROR: snow_intercept failed to converge to a solution "
-            "in root_brent.  Variable values will be dumped to the "
-            "screen, check for invalid values.\n");
+    log_warn("snow_intercept failed to converge to a solution "
+             "in root_brent.  Variable values will be dumped to the "
+             "screen, check for invalid values.");
 
     /* General Model Parameters */
     fprintf(LOG_DEST, "band = %i\n", band);
@@ -829,12 +824,9 @@ error_print_canopy_energy_bal(double  Tfoliage,
     fprintf(LOG_DEST, "*SensibleHeat = %f\n", *SensibleHeat);
     fprintf(LOG_DEST, "*VaporMassFlux = %f\n", *VaporMassFlux);
 
-    /* call error handling routine */
-    fprintf(LOG_DEST, "**********\n**********\n"
-            "Finished dumping snow_intercept "
-            "variables.\nTry increasing SNOW_DT to get model to "
-            "complete cell.\nThen check output for instabilities."
-            "\n**********\n**********\n");
+    log_warn("Finished dumping snow_intercept variables.\n"
+             "Try increasing SNOW_DT to get model to complete cell.\n"
+             "Then check output for instabilities.");
 
     return(ERROR);
 }

--- a/vic/vic_run/src/snow_melt.c
+++ b/vic/vic_run/src/snow_melt.c
@@ -100,8 +100,6 @@ snow_melt(double            Le,
     double                   advected_sensible_heat;
     double                   melt_energy = 0.;
 
-    char                     ErrorString[MAXSTRING];
-
     SnowFall = snowfall / MM_PER_M; /* convet to m */
     RainFall = rainfall / MM_PER_M; /* convet to m */
 
@@ -269,7 +267,7 @@ snow_melt(double            Le,
                 snow->surf_temp = root_brent(
                     (double) (snow->surf_temp - param.SNOW_DT),
                     (double) (snow->surf_temp + param.SNOW_DT),
-                    ErrorString, SnowPackEnergyBalance,
+                    SnowPackEnergyBalance,
                     delta_t, aero_resist, aero_resist_used, z2, Z0,
                     density, vp, LongSnowIn, Le, pressure,
                     RainFall, NetShortSnow, vpd,
@@ -617,8 +615,6 @@ ErrorPrintSnowPackEnergyBalance(double  TSurf,
     double *SurfaceMassFlux;        /* Mass flux of water vapor to or from the
                                          intercepted snow */
 
-    char   *ErrorString;
-
     /* Read Variable Argument List */
 
     /* General Model Parameters */
@@ -666,13 +662,11 @@ ErrorPrintSnowPackEnergyBalance(double  TSurf,
     VaporMassFlux = (double *) va_arg(ap, double *);
     BlowingMassFlux = (double *) va_arg(ap, double *);
     SurfaceMassFlux = (double *) va_arg(ap, double *);
-    ErrorString = (char *) va_arg(ap, char *);
 
     /* print variables */
-    fprintf(LOG_DEST, "%s", ErrorString);
-    fprintf(LOG_DEST, "ERROR: snow_melt failed to converge to a solution in "
-            "root_brent.  Variable values will be dumped to the "
-            "screen, check for invalid values.\n");
+    log_warn("snow_melt failed to converge to a solution in "
+             "root_brent.  Variable values will be dumped to the "
+             "screen, check for invalid values.");
 
     /* general model terms */
     fprintf(LOG_DEST, "iveg = %i\n", iveg);
@@ -718,9 +712,9 @@ ErrorPrintSnowPackEnergyBalance(double  TSurf,
     fprintf(LOG_DEST, "BlowingMassFlux = %f\n", BlowingMassFlux[0]);
     fprintf(LOG_DEST, "SurfaceMassFlux = %f\n", SurfaceMassFlux[0]);
 
-    fprintf(LOG_DEST, "Finished dumping snow_melt variables.\nTry increasing "
-            "SNOW_DT to get model to complete cell.\nThencheck output "
-            "for instabilities.\n");
+    log_warn("Finished dumping snow_melt variables.\nTry increasing "
+             "SNOW_DT to get model to complete cell.\nThencheck output "
+             "for instabilities.");
 
     return(ERROR);
 }


### PR DESCRIPTION
This silences all warnings about unused `ErrorString` variables.

xref: #581, #526