### PR TITLE
add scaling template for topaz

### DIFF
--- a/tests/run_profiling.py
+++ b/tests/run_profiling.py
@@ -19,7 +19,16 @@ import numpy as np
 from tonic.models.vic.vic import VIC
 
 host_config = namedtuple('host_config',
-                         ('max_cores', 'template', 'submit', 'mpiexec'))
+                         ('profile', 'template', 'submit', 'mpiexec'))
+
+
+def log2_range(m):
+    '''
+    make an array of integers that increase by 2^n with maximum value of m
+    '''
+    n = int(np.floor(np.log2(m))) + 1
+    return np.exp2(np.arange(n)).astype(np.int)
+
 
 table_header = '''----------------- START VIC SCALING PROFILE -----------------
 
@@ -29,7 +38,6 @@ User                      : $user
 VIC Test Git Version      : $git_version
 VIC Executable            : $vic_exe
 VIC Global Parameter File : $vic_global
-Test Maximum MPI Cores    : $max_cores
 
 VIC Executable Version Info
 ---------------------------
@@ -40,9 +48,13 @@ Cores | Time (Seconds)
 
 
 hosts = {
-    'local': host_config(max_cores=psutil.cpu_count(), submit=None, template=None,
+    'local': host_config(profile=[dict(np=np) for np in
+                                  log2_range(psutil.cpu_count())],
+                         submit=None,
+                         template=None,
                          mpiexec=os.getenv('MPIEXEC', 'mpiexec')),
-    'hydra': host_config(max_cores=64, submit='qsub', mpiexec='mpiexec',
+    'hydra': host_config(profile=[dict(np=np) for np in log2_range(64)],
+                         submit='qsub', mpiexec='mpiexec',
                          template='''#!/bin/bash
 #
 #$ -N VIC_scaling_test_$np
@@ -61,11 +73,45 @@ if [ "$np" -gt "64" ]
 fi
 
 START=$(date +%s)
-mpiexec -np $np $vic_exe -g $vic_global
+$mpiexec -np $np $vic_exe -g $vic_global
 END=$(date +%s)
 DIFF=$(echo "$END - $START" | bc)
 printf "%5s | %f" $np $DIFF >> $timing_table_file'''),
-    }
+    'topaz': host_config(profile=[dict(select=1, mpiprocs=1),
+                                  dict(select=1, mpiprocs=3),
+                                  dict(select=1, mpiprocs=9),
+                                  dict(select=1, mpiprocs=18),
+                                  dict(select=1, mpiprocs=36),
+                                  dict(select=2, mpiprocs=36),
+                                  dict(select=3, mpiprocs=36),
+                                  dict(select=4, mpiprocs=36),
+                                  dict(select=5, mpiprocs=36),
+                                  dict(select=6, mpiprocs=36),
+                                  dict(select=8, mpiprocs=36),
+                                  dict(select=10, mpiprocs=36),
+                                  dict(select=12, mpiprocs=36)],
+                         submit='qsub', mpiexec='mpiexec_mpt',
+                         template='''#!/bin/bash
+
+#!/bin/bash
+#PBS -N VIC_scaling_test_$np
+#PBS -q standard
+#PBS -A NPSCA07935242
+#PBS -l application=VIC
+#PBS -l select=$select:ncpus=36:mpiprocs=$mpiprocs
+#PBS -l walltime=04:00:00
+#PBS -j oe
+#PBS -o $WORKDIR
+
+# Qsub template for ERDC TOPAZ
+# Scheduler: PBS
+
+module load usp-netcdf/intel-15.0.3/4.3.3.1
+
+START=$(date +%s)
+mpiexec_mpt -np ${BC_MPI_TASKS_ALLOC} $vic_exe -g $vic_global
+DIFF=$(echo "$END - $START" | bc)
+printf "%5s | %f" ${BC_MPI_TASKS_ALLOC} $DIFF >> $timing_table_file''')}
 
 OUTPUT_WIDTH = 100
 
@@ -75,7 +121,8 @@ description = '''
 This is the VIC Profiling Test Suite. There are 2 main test types:
 
     1. Gprof Profiling: This test will generate a profiling call graph using
-        gprof. This test requires building your VIC executable with the flags `-pg`.
+        gprof. This test requires building your VIC executable with the
+        flags `-pg`.
     2. Scaling: This test will generate a MPI scaling timing table.
 -------------------------------------------------------------------------------
 '''
@@ -119,7 +166,8 @@ def main():
     parser.add_argument('--timing', '-t', type=str,
                         default='vic_timing_{}.txt'.format(ymd),
                         help='path to timing file')
-    parser.add_argument('--clean', action='store_true', help='Clean up run files')
+    parser.add_argument('--clean', action='store_true',
+                        help='Clean up run files')
     parser.add_argument('--test', action='store_true',
                         help='Test the setup but do not run VIC')
 
@@ -150,27 +198,27 @@ def run_scaling(args):
 
     # write timing file header
     header = string.Template(table_header)
-    header_kwargs = get_header_info(args.vic_exe, args.global_param,
-                                    config.max_cores)
+    header_kwargs = get_header_info(args.vic_exe, args.global_param)
     header = header.safe_substitute(**header_kwargs)
     with open(args.timing, 'w') as f:
         f.write(header)
 
-    for n in log2_range(config.max_cores).astype(np.int):
+    for i, kwargs in enumerate(config.profile):
         if config.template:
             # run on a cluster of some kind
             # start by printing the template
             print('-'.ljust(OUTPUT_WIDTH, '-'))
-            print('{host} template'.format(host=args.host).center(OUTPUT_WIDTH))
+            print('{host} template'.format(
+                host=args.host).center(OUTPUT_WIDTH))
             print('-'.ljust(OUTPUT_WIDTH, '-'))
             print(config.template)
             print('-'.ljust(OUTPUT_WIDTH, '-'))
             template = string.Template(config.template)
 
-            run_string = template.safe_substitute(np=n, vic_exe=args.vic_exe,
-                                                  vic_global=args.global_param,
-                                                  timing_table_file=args.timing)
-            run_file = 'vic_{host}_{n}.sh'.format(host=args.host, n=n)
+            run_string = template.safe_substitute(
+                vic_exe=args.vic_exe, vic_global=args.global_param,
+                timing_table_file=args.timing, **kwargs)
+            run_file = 'vic_{host}_{i}.sh'.format(host=args.host, i=i)
             with open(run_file, 'w') as f:
                 f.write(run_string)
 
@@ -184,6 +232,7 @@ def run_scaling(args):
                 os.remove(run_file)
         else:
             # run locally
+            n = kwargs['np']
             print('Running {} with {} processors'.format(args.vic_exe, n))
             if not args.test:
                 start = time.time()
@@ -196,24 +245,19 @@ def run_scaling(args):
     print('See %s for scaling table' % args.timing)
 
 
-def log2_range(m):
-    '''make an array of integers that increase by 2^n with maximum value of m'''
-    n = int(np.floor(np.log2(m))) + 1
-    return np.exp2(np.arange(n)).astype(np.int)
-
-
-def get_header_info(vic_exe, vic_global, max_cores):
+def get_header_info(vic_exe, vic_global):
     '''get info for timing table headers'''
     header_kwargs = {}
     header_kwargs['date'] = datetime.datetime.now()
     header_kwargs['hostname'] = socket.gethostname()
     header_kwargs['user'] = getpass.getuser()
     header_kwargs['git_version'] = subprocess.check_output(
-        ['git', 'describe', '--abbrev=4', '--dirty', '--always', '--tags']).decode()
+        ['git', 'describe', '--abbrev=4',
+         '--dirty', '--always', '--tags']).decode()
     header_kwargs['vic_exe'] = vic_exe
     header_kwargs['vic_global'] = vic_global
-    header_kwargs['max_cores'] = max_cores
-    header_kwargs['vic_version'] = subprocess.check_output([vic_exe, '-v']).decode()
+    header_kwargs['vic_version'] = subprocess.check_output(
+        [vic_exe, '-v']).decode()
     return header_kwargs
 
 


### PR DESCRIPTION
example output:

```
----------------- START VIC SCALING PROFILE -----------------

Date                      : 2016-08-27 23:22:59.602087
Machine                   : topaz03.erdc.hpc.mil
User                      : jhamman
VIC Test Git Version      : VIC.5.0.0.rc1-73-g5e21-dirty

VIC Executable            : /p/home/jhamman/VIC/vic/drivers/image/vic_image.exe
VIC Global Parameter File : /p/work2/jhamman/vic5_tests/test1/rasm_vic5_image_test1.global.txt

VIC Executable Version Info
---------------------------
$vic_version
Cores | Time (Seconds)
----------------------
  144 | 3463.000000
  180 | 2852.000000
  108 | 4455.000000
  288 | 1996.000000
  432 | 1526.000000
  216 | 2637.000000
  360 | 1739.000000
   72 | 6754.000000
  864 | 993.000000
   36 | 12026.000000
 1728 | 726.000000
```

cc @yixinmao for review and extension in followup pr.