### PR TITLE
Fixed NYEARS frequency when there are leap years

### DIFF
--- a/vic/drivers/shared_all/src/vic_time.c
+++ b/vic/drivers/shared_all/src/vic_time.c
@@ -859,13 +859,13 @@ time_delta(dmy_struct        *dmy_current,
             // if dmy_next.year is not leap year but date is Feb 29 !)
             make_lastday(global_param.calendar, dmy_next.year, lastday);
             dmy_next.day_in_year = 0;
-            for ( i = 1; i <= MONTHS_PER_YEAR; i++ ) {
-                if ( i < dmy_next.month ) {
-                    dmy_next.day_in_year += lastday[i-1];
-                }
-                else if ( i == dmy_next.month ) {
+            for ( i = 0; i < MONTHS_PER_YEAR; i++ ) {
+                if ( (i+1) == dmy_next.month ) {
                     dmy_next.day_in_year += dmy_next.day;
                     break;
+                }
+                else {
+                    dmy_next.day_in_year += lastday[i];
                 }
             }
         }

--- a/vic/drivers/shared_all/src/vic_time.c
+++ b/vic/drivers/shared_all/src/vic_time.c
@@ -820,6 +820,8 @@ time_delta(dmy_struct        *dmy_current,
 
     double                     td, a, b;
     dmy_struct                 dmy_next;
+    unsigned short int         lastday[MONTHS_PER_YEAR];
+    int                        i;
 
     // uniform timedeltas
     if (freq == FREQ_NSECONDS) {
@@ -851,7 +853,21 @@ time_delta(dmy_struct        *dmy_current,
             }
         }
         else if (freq == FREQ_NYEARS) {
+            // advance year
             dmy_next.year += n;
+            // re-calculate day_in_year (NOTE: currently will have problem
+            // if dmy_next.year is not leap year but date is Feb 29 !)
+            make_lastday(global_param.calendar, dmy_next.year, lastday);
+            dmy_next.day_in_year = 0;
+            for ( i = 1; i <= MONTHS_PER_YEAR; i++ ) {
+                if ( i < dmy_next.month ) {
+                    dmy_next.day_in_year += lastday[i-1];
+                }
+                else if ( i == dmy_next.month ) {
+                    dmy_next.day_in_year += dmy_next.day;
+                    break;
+                }
+            }
         }
         else {
             log_err("Unknown frequency found during time_delta computation");


### PR DESCRIPTION
Previously NYEARS frequency resulted in `day_in_year = 366` when advance from a leap year to a non-leap year. Fixed this problem by resetting `day_in_year` after advancing year(s).