### PR TITLE
Fixing a problem with image restarts when using multiple processors 

### DIFF
--- a/tests/system/system_tests.cfg
+++ b/tests/system/system_tests.cfg
@@ -144,6 +144,7 @@ STATE_FORMAT=BINARY
 test_description = Exact restart (falseFULL_ENERGY flaseFROZEN_SOIL) - image driver
 driver = image
 global_parameter_file = global.image.STEHE.restart.txt
+mpi_proc = 4
 expected_retval = 0
 check = exact_restart
 [[restart]]
@@ -158,6 +159,7 @@ FROZEN_SOIL=FALSE
 test_description = Exact restart (trueFULL_ENERGY flaseFROZEN_SOIL) - image driver
 driver = image
 global_parameter_file = global.image.STEHE.restart.txt
+mpi_proc = 4
 expected_retval = 0
 check = exact_restart
 [[restart]]
@@ -172,6 +174,7 @@ FROZEN_SOIL=FALSE
 test_description = Exact restart (falseFULL_ENERGY trueFROZEN_SOIL) - image driver
 driver = image
 global_parameter_file = global.image.STEHE.restart.FROZEN_SOIL.txt
+mpi_proc = 4
 expected_retval = 0
 check = exact_restart
 [[restart]]
@@ -187,6 +190,7 @@ NODES=10
 test_description = Exact restart (trueFULL_ENERGY trueFROZEN_SOIL) - image driver
 driver = image
 global_parameter_file = global.image.STEHE.restart.FROZEN_SOIL.txt
+mpi_proc = 4
 expected_retval = 0
 check = exact_restart
 [[restart]]

--- a/vic/drivers/shared_image/src/vic_restore.c
+++ b/vic/drivers/shared_image/src/vic_restore.c
@@ -39,6 +39,7 @@ vic_restore(void)
     extern veg_con_map_struct *veg_con_map;
     extern filenames_struct    filenames;
     extern metadata_struct     state_metadata[N_STATE_VARS];
+    extern int                 mpi_rank;
 
     int                        v;
     size_t                     i;
@@ -60,8 +61,9 @@ vic_restore(void)
     size_t                     d6start[6];
 
     // validate state file dimensions and coordinate variables
-    check_init_state_file();
-
+    if (mpi_rank == VIC_MPI_ROOT) {
+        check_init_state_file();
+    }
     // read state variables
 
     // allocate memory for variables to be stored


### PR DESCRIPTION
This PR fixes a problem with image restarts when using multiple processors. Edits were made to the vic_restore.c script to ensure that only the master node validates state file dimensions and coordinate variables. Multiprocessing was also added to a VIC Testing script.  