### PR TITLE
Fixed a bug when calculating steps of forcing to skip 

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -24,6 +24,10 @@ To check which release of VIC you are running:
 
 	After the fix, the timestamp appeared in the image driver output history filename is the beginning time of the time period in the file.
 
+2. Fixed forceskip rounding bug ([GH#639](https://github.com/UW-Hydro/VIC/pull/639))
+
+	After the fix, the `forceskip` variable in the global parameter structure (i.e., the number of timesteps to skip in the forcing data for the simulatin period) is rounded correctly (before the fix, rounding error might cause 1-timestep offset in the simulation results).
+
 ------------------------------
 
 ## VIC 5.0.0 [![DOI](https://zenodo.org/badge/7766/UW-Hydro/VIC.svg)](https://zenodo.org/badge/latestdoi/7766/UW-Hydro/VIC)

--- a/vic/drivers/shared_all/src/make_dmy.c
+++ b/vic/drivers/shared_all/src/make_dmy.c
@@ -98,8 +98,8 @@ make_dmy(global_param_struct *global)
                                  global->calendar, global->time_units);
 
             global->forceskip[i] =
-                (unsigned int) ((start_num - force_num) *
-                                (double) param_set.force_steps_per_day[i]);
+                (unsigned int) round((start_num - force_num) *
+                                    (double) param_set.force_steps_per_day[i]);
         }
     }
 


### PR DESCRIPTION
When calculating number of steps to skip in the forcing data, should round to integer first before converting to int type to prevent possible 1-timestep wrong offset (due to precision)