### PR TITLE
Improve Q12 calculation

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -19,6 +19,12 @@ To check which release of VIC you are running:
 
 **Release date: (Unreleased)**
 
+#### Model enhancement:
+
+1. Improved calculation of drainage between soil layers ([GH#656](https://github.com/UW-Hydro/VIC/pull/656))
+
+Drainage from upper layer to adjacent lower layer is calculated by Brook & Corey curve (which is a function of upper-layer soil moisture at the beginning of the timestep). In prevous versions, a simple numerical solution is applied which uses the timestep-beginning upper-layer soil moisture to calculate drainage rate, and assume this constant rate over the entire timestep. This can cause unreasonably large drainage if the curve has a steep shape and when soil moisture is high. Now, the current version uses exact integral (instead of numerical solution) for layer drainage calculation.
+
 
 ------------------------------
 
@@ -26,11 +32,6 @@ To check which release of VIC you are running:
 
 **Release date: (Unreleased)**
 
-#### Model enhancement:
-
-1. Improved calculation of drainage between soil layers ([GH#656](https://github.com/UW-Hydro/VIC/pull/656))
-
-Drainage from upper layer to adjacent lower layer is calculated by Brook & Corey curve (which is a function of upper-layer soil moisture at the beginning of the timestep). In prevous versions, a simple numerical solution is applied which uses the timestep-beginning upper-layer soil moisture to calculate drainage rate, and assume this constant rate over the entire timestep. This can cause unreasonably large drainage if the curve has a steep shape and when soil moisture is high. Now, the current version uses exact integral (instead of numerical solution) for layer drainage calculation.
 
 ------------------------------
 

--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -23,7 +23,7 @@ To check which release of VIC you are running:
 
 1. Improved calculation of drainage between soil layers ([GH#656](https://github.com/UW-Hydro/VIC/pull/656))
 
-Drainage from upper layer to adjacent lower layer is calculated by Brook & Corey curve (which is a function of upper-layer soil moisture at the beginning of the timestep). In prevous versions, a simple numerical solution is applied which uses the timestep-beginning upper-layer soil moisture to calculate drainage rate, and assume this constant rate over the entire timestep. This can cause unreasonably large drainage if the curve has a steep shape and when soil moisture is high. Now, the current version uses exact integral (instead of numerical solution) for layer drainage calculation.
+	Drainage from upper layer to adjacent lower layer is calculated according to Brook & Corey curve (where drainage rate is a function of upper-layer soil moisture). In previous versions, a simple numerical solution is applied which uses the timestep-beginning upper-layer soil moisture to calculate drainage rate, and assume this constant rate over the entire timestep. This can cause unreasonably large drainage if the curve has a steep shape and when soil moisture is high. Now, the current version uses exact integral (instead of numerical solution) for layer drainage calculation.
 
 
 ------------------------------

--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -15,10 +15,22 @@ To check which release of VIC you are running:
 
 ------------------------------
 
+## VIC 5.1.0
+
+**Release date: (Unreleased)**
+
+
+------------------------------
+
 ## VIC 5.0.1
 
 **Release date: (Unreleased)**
 
+#### Model enhancement:
+
+1. Improved calculation of drainage between soil layers ([GH#656](https://github.com/UW-Hydro/VIC/pull/656))
+
+Drainage from upper layer to adjacent lower layer is calculated by Brook & Corey curve (which is a function of upper-layer soil moisture at the beginning of the timestep). In prevous versions, a simple numerical solution is applied which uses the timestep-beginning upper-layer soil moisture to calculate drainage rate, and assume this constant rate over the entire timestep. This can cause unreasonably large drainage if the curve has a steep shape and when soil moisture is high. Now, the current version uses exact integral (instead of numerical solution) for layer drainage calculation.
 
 ------------------------------
 

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -113,6 +113,7 @@ void compute_pot_evap(size_t, double, double, double, double, double, double,
                       double, double *);
 void compute_runoff_and_asat(soil_con_struct *, double *, double, double *,
                              double *);
+double calc_Q12(double, double, double, double, double);
 void compute_soil_resp(int, double *, double, double, double *, double *,
                        double, double, double, double *, double *, double *);
 void compute_soil_layer_thermal_properties(layer_data_struct *, double *,

--- a/vic/vic_run/src/runoff.c
+++ b/vic/vic_run/src/runoff.c
@@ -200,12 +200,10 @@ runoff(cell_data_struct  *cell,
                 }
 
                 if (liq[lindex] > resid_moist[lindex]) {
-                    Q12[lindex] = Ksat[lindex] *
-                                  pow(((tmp_liq -
-                                        resid_moist[lindex]) /
-                                       (soil_con->max_moist[lindex] -
-                                        resid_moist[lindex])),
-                                      soil_con->expt[lindex]);
+                    Q12[lindex] = calc_Q12(Ksat[lindex], tmp_liq,
+                                           resid_moist[lindex],
+                                           soil_con->max_moist[lindex],
+                                           soil_con->expt[lindex]);
                 }
                 else {
                     Q12[lindex] = 0.;
@@ -487,3 +485,20 @@ compute_runoff_and_asat(soil_con_struct *soil_con,
         *runoff = 0.;
     }
 }
+
+/******************************************************************************
+* @brief    Calculate drainage between two layers
+******************************************************************************/
+double
+calc_Q12(double Ksat, double init_moist, double resid_moist,
+         double max_moist, double expt)
+{
+    double Q12;
+
+    Q12 = init_moist - pow(pow(init_moist - resid_moist, 1.0 - expt) -
+          Ksat / pow(max_moist - resid_moist, expt) * (1.0 - expt),
+          1.0 / (1.0 - expt)) - resid_moist;
+
+    return Q12;
+}
+


### PR DESCRIPTION
Drainage from upper layer to adjacent lower layer is calculated by Brook & Corey curve (where drainage rate is a function of upper-layer soil moisture). Before this PR, a simple numerical solution is applied which uses the timestep-beginning upper-layer soil moisture to calculate drainage rate, and assume this constant rate over the entire timestep. This can cause unreasonably large drainage if the curve has a steep shape and when soil moisture is high.

This PR modify layer drainage (Q12) calculation - use exact integral (instead of numerical solution) in order to avoid unreasonably-strong soil moisture oscilation when the Brook & Corey curve is steep.

This PR should close issue #655 