### PR TITLE
Fixed a bug - `forceskip` should be reset to zero at the beginning of every year

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -54,6 +54,10 @@ To check which release of VIC you are running:
 
 	Before the fix, the timestamps of long VIC runs were incorrect in some cases due to precision issue in timestamp generation. This resulted in incorrect output timestamps after running for a long period of time, or output termination. Please refer to [GH#668](https://github.com/UW-Hydro/VIC/pull/668) for details on this bug fix.
 
+10. Fixed a bug related to forcing and simulation start time ([GH#671](https://github.com/UW-Hydro/VIC/pull/671))
+
+	Before the fix, there would be an error if the simulation start time is later than the forcing start time that year AND the simulation spans multiple years. Fixed this bug.
+
  
 ------------------------------
 

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -72,8 +72,10 @@ vic_force(void)
 
     // global_param.forceoffset[0] resets every year since the met file restarts
     // every year
+    // global_param.forceskip[0] should also reset to 0 after the first year
     if (current > 1 && (dmy[current].year != dmy[current - 1].year)) {
         global_param.forceoffset[0] = 0;
+        global_param.forceskip[0] = 0;
     }
 
     // only the time slice changes for the met file reads. The rest is constant


### PR DESCRIPTION
Before this bug fix, there would be an error if the simulation start time is later than the forcing start time that year AND the simulation spans multiple years.