### PR TITLE
Cleaned up vic_store.c the part related to advancing dmy_current for state file timestamp

### DIFF
--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -138,6 +138,10 @@ vic_cesm_run(vic_clock *vclock)
     // Write history files
     vic_write_output(&dmy_current);
 
+    // advance the clock
+    advance_time();
+    assert_time_insync(vclock, &dmy_current);
+
     // if save:
     if (vclock->state_flag) {
         // write state file
@@ -147,10 +151,6 @@ vic_cesm_run(vic_clock *vclock)
 
     // reset x2l fields
     initialize_x2l_data();
-
-    // advance the clock
-    advance_time();
-    assert_time_insync(vclock, &dmy_current);
 
     // stop vic run timer
     timer_stop(&(global_timers[TIMER_VIC_RUN]));

--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -31,7 +31,7 @@
 
 #define VIC_DRIVER "Image"
 
-bool check_save_state_flag(size_t);
+bool check_save_state_flag(size_t, dmy_struct *dmy_offset);
 void display_current_settings(int);
 void get_forcing_file_info(param_set_struct *param_set, size_t file_num);
 void get_global_param(FILE *);

--- a/vic/drivers/image/src/check_save_state_flag.c
+++ b/vic/drivers/image/src/check_save_state_flag.c
@@ -32,14 +32,13 @@
  *          current time step
  *****************************************************************************/
 bool
-check_save_state_flag(size_t current)
+check_save_state_flag(size_t current, dmy_struct *dmy_offset)
 {
     extern global_param_struct global_param;
     extern dmy_struct         *dmy;
 
     double                     offset;
     double                     time_num;
-    dmy_struct                 dmy_offset;
 
     // Advance dmy by one timestep because dmy is the "timestep-beginning"
     // timestamp, but we want to check whether the end of the current
@@ -50,14 +49,14 @@ check_save_state_flag(size_t current)
     time_num += offset;
     num2date(global_param.time_origin_num, time_num, 0,
              global_param.calendar, TIME_UNITS_DAYS,
-             &dmy_offset);
+             dmy_offset);
 
     // Check if the end of the current time step is equal to the state output
     // timestep specified by user
-    if (dmy_offset.year == global_param.stateyear &&
-        dmy_offset.month == global_param.statemonth &&
-        dmy_offset.day == global_param.stateday &&
-        dmy_offset.dayseconds == global_param.statesec) {
+    if (dmy_offset->year == global_param.stateyear &&
+        dmy_offset->month == global_param.statemonth &&
+        dmy_offset->day == global_param.stateday &&
+        dmy_offset->dayseconds == global_param.statesec) {
         return true;
     }
     else {

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -33,6 +33,7 @@ size_t             *mpi_map_mapping_array = NULL;
 all_vars_struct    *all_vars = NULL;
 force_data_struct  *force = NULL;
 dmy_struct         *dmy = NULL;
+dmy_struct          dmy_state;
 filenames_struct    filenames;
 filep_struct        filep;
 domain_struct       global_domain;
@@ -142,9 +143,9 @@ main(int    argc,
         vic_write_output(&(dmy[current]));
 
         // Write state file
-        if (check_save_state_flag(current)) {
+        if (check_save_state_flag(current, &dmy_state)) {
             debug("writing state file for timestep %zu", current);
-            vic_store(&(dmy[current]), state_filename);
+            vic_store(&dmy_state, state_filename);
             debug("finished storing state file: %s", state_filename)
         }
     }

--- a/vic/drivers/shared_image/include/vic_driver_shared_image.h
+++ b/vic/drivers/shared_image/include/vic_driver_shared_image.h
@@ -221,7 +221,7 @@ void initialize_global_structures(void);
 void initialize_history_file(nc_file_struct *nc, stream_struct *stream,
                              dmy_struct *dmy_current);
 void initialize_state_file(char *filename, nc_file_struct *nc_state_file,
-                           dmy_struct *dmy_current);
+                           dmy_struct *dmy_state);
 void initialize_location(location_struct *location);
 int initialize_model_state(all_vars_struct *all_vars, size_t Nveg,
                            size_t Nnodes, double surf_temp,
@@ -256,7 +256,7 @@ void vic_init(void);
 void vic_init_output(dmy_struct *dmy_current);
 void vic_restore(void);
 void vic_start(void);
-void vic_store(dmy_struct *dmy_current, char *state_filename);
+void vic_store(dmy_struct *dmy_state, char *state_filename);
 void vic_write(stream_struct *stream, nc_file_struct *nc_hist_file,
                dmy_struct *dmy_current);
 void vic_write_output(dmy_struct *dmy);


### PR DESCRIPTION
In `vic_store()`, we now directly pass in the state time structure (at the state time point) instead of `dmy_current` (which is the beginning of the timestep and one timestep ahead of the state time point). This change will avoid repeatedly advancing one timestep from `dmy_current` in multiple places of the code.

- [x] Image driver
- [x] CESM driver - @dgergel , I think the easiest way is that you pull my branch and make a PR to my branch `clean_up_dmy_vic_store`. Ideally all the remaining changes should happen only under `drivers/cesm`.
