### PR TITLE
Fixed some remaining bugs related to reseting forceskip to zero

### DIFF
--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -73,7 +73,7 @@ vic_force(void)
     // global_param.forceoffset[0] resets every year since the met file restarts
     // every year
     // global_param.forceskip[0] should also reset to 0 after the first year
-    if (current > 1 && (dmy[current].year != dmy[current - 1].year)) {
+    if (current > 0 && (dmy[current].year != dmy[current - 1].year)) {
         global_param.forceoffset[0] = 0;
         global_param.forceskip[0] = 0;
     }
@@ -264,8 +264,10 @@ vic_force(void)
 
         // global_param.forceoffset[1] resets every year since the met file restarts
         // every year
-        if (current > 1 && (dmy[current].year != dmy[current - 1].year)) {
+        // global_param.forceskip[1] should also reset to 0 after the first year
+        if (current > 0 && (dmy[current].year != dmy[current - 1].year)) {
             global_param.forceoffset[1] = 0;
+            global_param.forceskip[0] = 0;
         }
 
         // only the time slice changes for the met file reads. The rest is constant

--- a/vic/drivers/image/src/vic_force.c
+++ b/vic/drivers/image/src/vic_force.c
@@ -267,7 +267,7 @@ vic_force(void)
         // global_param.forceskip[1] should also reset to 0 after the first year
         if (current > 0 && (dmy[current].year != dmy[current - 1].year)) {
             global_param.forceoffset[1] = 0;
-            global_param.forceskip[0] = 0;
+            global_param.forceskip[1] = 0;
         }
 
         // only the time slice changes for the met file reads. The rest is constant


### PR DESCRIPTION
In PR #671 that fixed bugs to reset `forceskip` to zero at the beginning of every year, there were some parts missing which are addressed in this PR:
- `forceskip` for forcing[1] (the second forcing file, if specified) should also be reset to zero every year
- The check for new year should start from the second timestep (not the third)

