### PR TITLE
Feature/implement runcell changes and netcdf speedup cesm driver

### DIFF
--- a/vic/drivers/cesm/src/display_current_settings.c
+++ b/vic/drivers/cesm/src/display_current_settings.c
@@ -266,7 +266,7 @@ display_current_settings(int mode)
 
     fprintf(LOG_DEST, "\n");
     fprintf(LOG_DEST, "Constants File\t\t%s\n", filenames.constants);
-    fprintf(LOG_DEST, "Parameters file\t\t%s\n", filenames.params);
+    fprintf(LOG_DEST, "Parameters file\t\t%s\n", filenames.params.nc_filename);
     if (options.BASEFLOW == ARNO) {
         fprintf(LOG_DEST, "BASEFLOW\t\tARNO\n");
     }

--- a/vic/drivers/cesm/src/display_current_settings.c
+++ b/vic/drivers/cesm/src/display_current_settings.c
@@ -262,7 +262,7 @@ display_current_settings(int mode)
 
     fprintf(LOG_DEST, "\n");
     fprintf(LOG_DEST, "Input Domain Data:\n");
-    fprintf(LOG_DEST, "Domain file\t\t%s\n", filenames.domain);
+    fprintf(LOG_DEST, "Domain file\t\t%s\n", filenames.domain.nc_filename);
 
     fprintf(LOG_DEST, "\n");
     fprintf(LOG_DEST, "Constants File\t\t%s\n", filenames.constants);
@@ -361,7 +361,7 @@ display_current_settings(int mode)
     fprintf(LOG_DEST, "\n");
     fprintf(LOG_DEST, "Input State File:\n");
     if (options.INIT_STATE) {
-        fprintf(LOG_DEST, "INIT_STATE\t\tTRUE\t%s\n", filenames.init_state);
+        fprintf(LOG_DEST, "INIT_STATE\t\tTRUE\t%s\n", filenames.init_state.nc_filename);
         if (options.STATE_FORMAT == NETCDF3_CLASSIC) {
             fprintf(LOG_DEST, "STATE_FORMAT\t\tNETCDF3_CLASSIC\n");
         }

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -247,7 +247,7 @@ get_global_param(FILE *gp)
                 }
                 else {
                     options.INIT_STATE = true;
-                    strcpy(filenames.init_state, flgstr);
+                    strcpy(filenames.init_state.nc_filename, flgstr);
                 }
             }
             // Define state file format
@@ -279,13 +279,13 @@ get_global_param(FILE *gp)
                 sscanf(cmdstr, "%*s %s", filenames.constants);
             }
             else if (strcasecmp("DOMAIN", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", filenames.domain);
+                sscanf(cmdstr, "%*s %s", filenames.domain.nc_filename);
             }
             else if (strcasecmp("DOMAIN_TYPE", optstr) == 0) {
                 get_domain_type(cmdstr);
             }
             else if (strcasecmp("PARAMETERS", optstr) == 0) {
-                sscanf(cmdstr, "%*s %s", filenames.params);
+                sscanf(cmdstr, "%*s %s", filenames.params.nc_filename);
             }
             else if (strcasecmp("ARNO_PARAMS", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
@@ -482,7 +482,7 @@ validate_filenames(filenames_struct *filenames)
     }
 
     // Validate parameter file information
-    if (strcmp(filenames->params, "MISSING") == 0) {
+    if (strcmp(filenames->params.nc_filename, "MISSING") == 0) {
         log_err("A parameters file has not been defined.  Make sure that the "
                 "global file defines the parameters parameter file on the line "
                 "that begins with \"PARAMETERS\".");

--- a/vic/drivers/cesm/src/vic_populate_model_state.c
+++ b/vic/drivers/cesm/src/vic_populate_model_state.c
@@ -51,7 +51,7 @@ vic_populate_model_state(char *runtype_str)
     // read the model state from the netcdf file
     if (runtype == CESM_RUNTYPE_RESTART || runtype == CESM_RUNTYPE_BRANCH) {
         // Get restart file from rpointer file
-        read_rpointer_file(filenames.init_state);
+        read_rpointer_file(filenames.init_state.nc_filename);
 
         // set options.INIT_STATE to true since we have found a state file in
         // the rpointer file.

--- a/vic/vic_run/src/runoff.c
+++ b/vic/vic_run/src/runoff.c
@@ -199,7 +199,7 @@ runoff(cell_data_struct  *cell,
                     tmp_liq = resid_moist[lindex];
                 }
 
-                if (liq[lindex] > resid_moist[lindex]) {
+                if (tmp_liq > resid_moist[lindex]) {
                     Q12[lindex] = calc_Q12(Ksat[lindex], tmp_liq,
                                            resid_moist[lindex],
                                            soil_con->max_moist[lindex],


### PR DESCRIPTION
- applies run_cell changes from PR #662 to the CESM driver
- fixes bug that was occurring when initial moisture was not greater than residual moisture (occurs in the Arctic for a few grid cells at certain time steps when soil moisture is very low), this is fixed by checking to make sure that initial moisture is greater than residual moisture and if not we skip the calc_Q12 calculation, since there should be no drainage in that case. Previously this check was implemented but was not checking the correct variable
- applies netCDF speedup changes from #684 to the CESM driver

cc @yixinmao, @jhamman, @bartnijssen for review. 