### PR TITLE
Feature/fix latent heat and longwave coupler fields

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -25,7 +25,9 @@ To check which release of VIC you are running:
 
 	Drainage from upper layer to adjacent lower layer is calculated according to Brook & Corey curve (where drainage rate is a function of upper-layer soil moisture). In previous versions, a simple numerical solution is applied which uses the timestep-beginning upper-layer soil moisture to calculate drainage rate, and assume this constant rate over the entire timestep. This can cause unreasonably large drainage if the curve has a steep shape and when soil moisture is high. Now, the current version uses exact integral (instead of numerical solution) for layer drainage calculation.
 
-2. Fixes for the CESM driver ([GH#642](https://github.com/UW-Hydro/VIC/pull/642))
+2. Fixes for the CESM driver 
+
+	([GH#642](https://github.com/UW-Hydro/VIC/pull/642))
 
 	1. Using correct fill value datatypes in MPI Gather steps 
 	2. Updated state file name time step to be period-ending rather than period-beginning
@@ -35,6 +37,11 @@ To check which release of VIC you are running:
 	6. Changed pressure units from kPa to Pa
 	7. Fixed bug that prevented using the correct local domain grid cells in `cesm_put_data.c`
 	8. Changed reference temperature units from Celsius to Kelvin in `cesm_put_data.c`
+
+	([GH#693](https://github.com/UW-Hydro/VIC/pull/693))
+
+	1. Fix sign for latent heat fluxes passed from VIC to the coupler
+	2. Fix sign for longwave radiation passed from VIC to the coupler
 
 ------------------------------
 

--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -38,7 +38,7 @@ To check which release of VIC you are running:
 	7. Fixed bug that prevented using the correct local domain grid cells in `cesm_put_data.c`
 	8. Changed reference temperature units from Celsius to Kelvin in `cesm_put_data.c`
 
-	([GH#693](https://github.com/UW-Hydro/VIC/pull/693))
+	[GH#695](https://github.com/UW-Hydro/VIC/pull/695)
 
 	1. Fix sign for latent heat fluxes passed from VIC to the coupler
 	2. Fix sign for longwave radiation passed from VIC to the coupler

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -249,7 +249,7 @@ vic_cesm_put_data()
 
                 // latent heat flux
                 // CESM units: W m-2
-                l2x_vic[i].l2x_Fall_lat += -1 * AreaFactor * energy.AtmosLatent;
+                l2x_vic[i].l2x_Fall_lat += AreaFactor * energy.AtmosLatent;
 
                 // sensible heat flux
                 // CESM units: W m-2

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -258,7 +258,7 @@ vic_cesm_put_data()
 
                 // upward longwave heat flux
                 // CESM units: W m-2
-                l2x_vic[i].l2x_Fall_lwup += AreaFactor *
+                l2x_vic[i].l2x_Fall_lwup += -1 *  AreaFactor *
                                             (force[i].longwave[NR] -
                                              energy.NetLongAtmos);
 


### PR DESCRIPTION
This PR makes the following changes in the CESM driver: 

- fixes sign for latent heat flux passed from VIC to the coupler
- fixes sign for longwave radiation (lwup) passed from VIC to the coupler 