### PR TITLE
Feature/fix RASM RFR compiling conflict

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -36,6 +36,9 @@ To check which release of VIC you are running:
 	7. Fixed bug that prevented using the correct local domain grid cells in `cesm_put_data.c`
 	8. Changed reference temperature units from Celsius to Kelvin in `cesm_put_data.c`
 
+	[GH#696](https://github.com/UW-Hydro/VIC/pull/696)
+
+	1. Changes names of CESM driver functions `trim` and `advance_time` to `trimstr` and `advance_vic_time`, respectively, to avoid conflicts with WRF functions with the same names when compiling RFR case. 
 ------------------------------
 
 ## VIC 5.0.1

--- a/vic/drivers/cesm/include/vic_driver_cesm.h
+++ b/vic/drivers/cesm/include/vic_driver_cesm.h
@@ -157,7 +157,7 @@ typedef struct {
     bool l2x_vars_set; /** l2x set flag */
 } l2x_data_struct;
 
-void advance_time(void);
+void advance_vic_time(void);
 void assert_time_insync(vic_clock *vclock, dmy_struct *dmy);
 void get_global_param(FILE *);
 void initialize_cesm_time(void);

--- a/vic/drivers/cesm/include/vic_driver_cesm.h
+++ b/vic/drivers/cesm/include/vic_driver_cesm.h
@@ -171,7 +171,7 @@ void print_vic_clock(vic_clock *vclock);
 void print_x2l_data(x2l_data_struct *x2l);
 void read_rpointer_file(char *fname);
 unsigned short int start_type_from_char(char *start_str);
-char *trim(char *str);
+char *trimstr(char *str);
 void validate_filenames(filenames_struct *filenames);
 void validate_global_param(global_param_struct *global_param);
 void validate_options(option_struct *options);

--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -139,7 +139,7 @@ vic_cesm_run(vic_clock *vclock)
     vic_write_output(&dmy_current);
 
     // advance the clock
-    advance_time();
+    advance_vic_time();
     assert_time_insync(vclock, &dmy_current);
 
     // if save:

--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -94,7 +94,7 @@ vic_cesm_init(vic_clock     *vclock,
     vic_init();
 
     // populate model state, either using a cold start or from a restart file
-    vic_populate_model_state(trim(cmeta->starttype));
+    vic_populate_model_state(trimstr(cmeta->starttype));
 
     // initialize forcings
     vic_force();

--- a/vic/drivers/cesm/src/print_library_cesm.c
+++ b/vic/drivers/cesm/src/print_library_cesm.c
@@ -41,7 +41,7 @@ print_vic_clock(vic_clock *vclock)
             vclock->current_dayseconds);
     fprintf(LOG_DEST, "\tstate_flag         : %d\n", vclock->state_flag);
     fprintf(LOG_DEST, "\tstop_flag          : %d\n", vclock->stop_flag);
-    fprintf(LOG_DEST, "\tcalendar           : %s\n", trim(vclock->calendar));
+    fprintf(LOG_DEST, "\tcalendar           : %s\n", trimstr(vclock->calendar));
 }
 
 /******************************************************************************
@@ -51,12 +51,12 @@ void
 print_case_metadata(case_metadata *cmeta)
 {
     fprintf(LOG_DEST, "case_metadata   :\n");
-    fprintf(LOG_DEST, "\tcaseid        : %s\n", trim(cmeta->caseid));
-    fprintf(LOG_DEST, "\tcasedesc      : %s\n", trim(cmeta->casedesc));
-    fprintf(LOG_DEST, "\tstarttype     : %s\n", trim(cmeta->starttype));
-    fprintf(LOG_DEST, "\tmodel_version : %s\n", trim(cmeta->model_version));
-    fprintf(LOG_DEST, "\thostname      : %s\n", trim(cmeta->hostname));
-    fprintf(LOG_DEST, "\tusername      : %s\n", trim(cmeta->username));
+    fprintf(LOG_DEST, "\tcaseid        : %s\n", trimstr(cmeta->caseid));
+    fprintf(LOG_DEST, "\tcasedesc      : %s\n", trimstr(cmeta->casedesc));
+    fprintf(LOG_DEST, "\tstarttype     : %s\n", trimstr(cmeta->starttype));
+    fprintf(LOG_DEST, "\tmodel_version : %s\n", trimstr(cmeta->model_version));
+    fprintf(LOG_DEST, "\thostname      : %s\n", trimstr(cmeta->hostname));
+    fprintf(LOG_DEST, "\tusername      : %s\n", trimstr(cmeta->username));
 }
 
 /******************************************************************************

--- a/vic/drivers/cesm/src/vic_cesm_start.c
+++ b/vic/drivers/cesm/src/vic_cesm_start.c
@@ -48,7 +48,7 @@ vic_cesm_start(vic_clock     *vclock,
         strcpy(filenames.global, GLOBALPARAM);
 
 	// assign case name to state file name
-    	strncpy(filenames.statefile, trim(cmeta->caseid),
+    	strncpy(filenames.statefile, trimstr(cmeta->caseid),
                 sizeof(filenames.statefile));
 
         // read global settings
@@ -76,7 +76,7 @@ vic_cesm_start(vic_clock     *vclock,
         global_param.nrecs = 1;
 
         // Calendar
-        global_param.calendar = str_to_calendar(trim(vclock->calendar));
+        global_param.calendar = str_to_calendar(trimstr(vclock->calendar));
         // set NR and NF
         NF = global_param.snow_steps_per_day / global_param.model_steps_per_day;
         if (NF == 1) {
@@ -107,7 +107,7 @@ vic_cesm_start(vic_clock     *vclock,
  *           using free() etc.
  *****************************************************************************/
 char *
-trim(char *str)
+trimstr(char *str)
 {
     char *end;
 

--- a/vic/drivers/cesm/src/vic_cesm_time.c
+++ b/vic/drivers/cesm/src/vic_cesm_time.c
@@ -66,7 +66,7 @@ initialize_cesm_time(void)
  * @brief    Advance one timestep
  *****************************************************************************/
 void
-advance_time(void)
+advance_vic_time(void)
 {
     extern size_t              current;
     extern dmy_struct          dmy_current;


### PR DESCRIPTION
This PR addresses a conflict that was occurring when compiling a RASM RFR case where two CESM driver functions - `trim` and `advance_time` - were causing conflicts with WRF functions of the same name. I have renamed them as follows: 
- `trim` -> `trimstr`
- `advance_time` -> `advance_vic_time`