### PR TITLE
Feature/fix aerodynamic resistance and roughness

### DIFF
--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -76,9 +76,6 @@ int
 vic_cesm_init(vic_clock     *vclock,
               case_metadata *cmeta)
 {
-    global_param_struct global_param; 
-    option_struct       options;
-
     // start vic all timer
     timer_start(&(global_timers[TIMER_VIC_ALL]));
     // start vic init timer

--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -76,6 +76,9 @@ int
 vic_cesm_init(vic_clock     *vclock,
               case_metadata *cmeta)
 {
+    global_param_struct global_param; 
+    option_struct       options;
+
     // start vic all timer
     timer_start(&(global_timers[TIMER_VIC_ALL]));
     // start vic init timer
@@ -101,6 +104,12 @@ vic_cesm_init(vic_clock     *vclock,
 
     // initialize output structures
     vic_init_output(&dmy_current);
+
+    // initialization is complete, print settings
+    log_info(
+	"Initialization is complete, print global param and options structures");
+    print_global_param(&global_param);
+    print_option(&options);
 
     // stop init timer
     timer_stop(&(global_timers[TIMER_VIC_INIT]));

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -75,7 +75,7 @@ get_global_param(FILE *gp)
 	    else if (strcasecmp("FULL_ENERGY", optstr) == 0) {
 		sscanf(cmdstr, "%*s %s", flgstr);
 		options.FULL_ENERGY = str_to_bool(flgstr);
-		if (options.FULL_ENERGY == FALSE) {
+		if (options.FULL_ENERGY == false) {
 		    log_warn("FULL_ENERGY is set to FALSE. Please double check "
 			      "that this is the setting you intended.");
 		}

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -75,6 +75,10 @@ get_global_param(FILE *gp)
 	    else if (strcasecmp("FULL_ENERGY", optstr) == 0) {
 		sscanf(cmdstr, "%*s %s", flgstr);
 		options.FULL_ENERGY = str_to_bool(flgstr);
+		if (options.FULL_ENERGY == FALSE) {
+		    log_warn("FULL_ENERGY is set to FALSE. Please double check "
+			      "that this is the setting you intended.");
+		}
 	    }
             else if (strcasecmp("FROZEN_SOIL", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -72,6 +72,10 @@ get_global_param(FILE *gp)
                 sscanf(cmdstr, "%*s %s", flgstr);
                 global_param.time_units = str_to_timeunits(flgstr);
             }
+	    else if (strcasecmp("FULL_ENERGY", optstr) == 0) {
+		sscanf(cmdstr, "%*s %s", flgstr);
+		options.FULL_ENERGY = str_to_bool(flgstr);
+	    }
             else if (strcasecmp("FROZEN_SOIL", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
                 options.FROZEN_SOIL = str_to_bool(flgstr);

--- a/vic/drivers/cesm/src/vic_force.c
+++ b/vic/drivers/cesm/src/vic_force.c
@@ -45,6 +45,7 @@ vic_force(void)
     extern option_struct       options;
     extern soil_con_struct    *soil_con;
     extern veg_con_map_struct *veg_con_map;
+    extern veg_con_struct    **veg_con;
     extern veg_hist_struct   **veg_hist;
     extern veg_lib_struct    **veg_lib;
     extern parameters_struct   param;
@@ -261,15 +262,15 @@ vic_force(void)
             if (vidx != NODATA_VEG) {
                 for (j = 0; j < NF; j++) {
                     veg_hist[i][vidx].albedo[j] =
-                        veg_lib[i][v].albedo[dmy_current.month - 1];
+                        veg_con[i][vidx].albedo[dmy_current.month - 1];
                     veg_hist[i][vidx].displacement[j] =
-                        veg_lib[i][v].displacement[dmy_current.month - 1];
+                        veg_con[i][vidx].displacement[dmy_current.month - 1];
                     veg_hist[i][vidx].fcanopy[j] =
-                        veg_lib[i][v].fcanopy[dmy_current.month - 1];
+                        veg_con[i][vidx].fcanopy[dmy_current.month - 1];
                     veg_hist[i][vidx].LAI[j] =
-                        veg_lib[i][v].LAI[dmy_current.month - 1];
+                        veg_con[i][vidx].LAI[dmy_current.month - 1];
                     veg_hist[i][vidx].roughness[j] =
-                        veg_lib[i][v].roughness[dmy_current.month - 1];
+                        veg_con[i][vidx].roughness[dmy_current.month - 1];
                 }
                 // not the correct way to calculate average albedo, but leave
                 // for now


### PR DESCRIPTION
This PR makes the following changes to the CESM driver: 

- updates the veg hist structure in accordance with the image and classic drivers
- now correctly reads in the FULL_ENERGY option from the global parameter file (it was previously defaulting to False because it wasn't being read in)
- adds printing of global parameter file options after model initialization (this is currently done in image mode and I think it's a very useful feature)