### PR TITLE
add variable name for restart test debugging

### DIFF
--- a/tests/test_image_driver.py
+++ b/tests/test_image_driver.py
@@ -291,4 +291,5 @@ def check_mpi_states(state_basedir, list_n_proc):
         for var in ds_first_run.data_vars:
             npt.assert_array_equal(ds_current_run[var].values,
                                    ds_first_run[var].values,
-                                   err_msg='States are not an exact match')
+                                   err_msg='States are not an exact match '
+                                   'for variable: {}'.format(var))


### PR DESCRIPTION
This PR enables outputting variable name when comparing variables in a state file for simulations run with different numbers of processors. 