### PR TITLE
pass gridcell averaged albedo from all_vars struct to wrf

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -47,9 +47,13 @@ To check which release of VIC you are running:
 
 	    Changes names of CESM driver functions `trim` and `advance_time` to `trimstr` and `advance_vic_time`, respectively, to avoid conflicts with WRF functions with the same names when compiling RFR case.
 
-        [GH#702] (https://github.com/UW-Hydro/VIC/pull/702)
+    [GH#702] (https://github.com/UW-Hydro/VIC/pull/702)
 
-	    Fixes Julian day for the first timestep in the dmy struct for the CESM driver.
+        Fixes Julian day for the first timestep in the dmy struct for the CESM driver.
+
+	[GH#710] (https://github.com/UW-Hydro/VIC/pull/710)
+
+	    Refactor the cesm_put_data.c routine in the CESM driver to use values from out_data directly, rather than computing them separately in cesm_put_data.c. 
 
 3. Speed up NetCDF operations in the image/CESM drivers ([GH#684](https://github.com/UW-Hydro/VIC/pull/684))
 

--- a/vic/drivers/cesm/include/vic_driver_cesm.h
+++ b/vic/drivers/cesm/include/vic_driver_cesm.h
@@ -188,7 +188,7 @@ void vic_cesm_start(vic_clock *vclock, case_metadata *cmeta);
 void vic_initialize_albedo(void);
 void vic_initialize_lwup(void);
 void vic_initialize_temperature(void);
-void vic_populate_model_state(char *runtype_str);
+void vic_populate_model_state(char *runtype_str, dmy_struct *dmy_current);
 void write_rpointer_file(char *fname);
 
 #endif

--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -94,7 +94,7 @@ vic_cesm_init(vic_clock     *vclock,
     vic_init();
 
     // populate model state, either using a cold start or from a restart file
-    vic_populate_model_state(trimstr(cmeta->starttype));
+    vic_populate_model_state(trimstr(cmeta->starttype), &dmy_current);
 
     // initialize forcings
     vic_force();

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -44,6 +44,7 @@ vic_cesm_put_data()
     extern global_param_struct global_param;
     extern option_struct       options;
     extern parameters_struct   param;
+    extern double           ***out_data;
 
     bool                       IsWet = false; // TODO: add lake fraction
     bool                       overstory;
@@ -63,14 +64,13 @@ vic_cesm_put_data()
     double                     wind_stress;
     double                     wind_stress_x;
     double                     wind_stress_y;
-    double                     evap;
     cell_data_struct           cell;
     energy_bal_struct          energy;
     snow_data_struct           snow;
     veg_var_struct             veg_var;
 
     for (i = 0; i < local_domain.ncells_active; i++) {
-        // Zero l2x vars (leave unused fields as MISSING values)
+        // Zero l2x vars
         l2x_vic[i].l2x_Sl_t = 0;
         l2x_vic[i].l2x_Sl_tref = 0;
         l2x_vic[i].l2x_Sl_qref = 0;
@@ -80,7 +80,7 @@ vic_cesm_put_data()
         l2x_vic[i].l2x_Sl_anidf = 0;
         l2x_vic[i].l2x_Sl_snowh = 0;
         l2x_vic[i].l2x_Sl_u10 = 0;
-        // l2x_vic[i].l2x_Sl_ddvel = 0;
+        l2x_vic[i].l2x_Sl_ddvel = 0;
         l2x_vic[i].l2x_Sl_fv = 0;
         l2x_vic[i].l2x_Sl_ram1 = 0;
         l2x_vic[i].l2x_Sl_logz0 = 0;
@@ -91,14 +91,84 @@ vic_cesm_put_data()
         l2x_vic[i].l2x_Fall_lwup = 0;
         l2x_vic[i].l2x_Fall_evap = 0;
         l2x_vic[i].l2x_Fall_swnet = 0;
-        // l2x_vic[i].l2x_Fall_fco2_lnd = 0;
-        // l2x_vic[i].l2x_Fall_flxdst1 = 0;
-        // l2x_vic[i].l2x_Fall_flxdst2 = 0;
-        // l2x_vic[i].l2x_Fall_flxdst3 = 0;
-        // l2x_vic[i].l2x_Fall_flxdst4 = 0;
-        // l2x_vic[i].l2x_Fall_flxvoc = 0;
+        l2x_vic[i].l2x_Fall_fco2_lnd = 0;
+        l2x_vic[i].l2x_Fall_flxdst1 = 0;
+        l2x_vic[i].l2x_Fall_flxdst2 = 0;
+        l2x_vic[i].l2x_Fall_flxdst3 = 0;
+        l2x_vic[i].l2x_Fall_flxdst4 = 0;
+        l2x_vic[i].l2x_Fall_flxvoc = 0;
         l2x_vic[i].l2x_Flrl_rofliq = 0;
-        // l2x_vic[i].l2x_Flrl_rofice = 0;
+        l2x_vic[i].l2x_Flrl_rofice = 0;
+
+        // populate reference values
+
+        // 10m wind, VIC: m/s, CESM: m/s
+        l2x_vic[i].l2x_Sl_u10 = out_data[i][OUT_WIND][0];
+
+        // 2m reference temperature, VIC: C, CESM: K
+        l2x_vic[i].l2x_Sl_tref = out_data[i][OUT_AIR_TEMP][0] + CONST_TKFRZ;
+
+        // 2m reference specific humidity, VIC: kg/kg, CESM: g/g
+        l2x_vic[i].l2x_Sl_qref = CONST_EPS *
+                                 out_data[i][OUT_VP][0] /
+                                 out_data[i][OUT_PRESSURE][0];
+
+        // band-specific quantities
+        // note that these include a veg correction (AreaFactor)
+        // that is already in the put_data routine
+
+        // temperature, VIC: K, CESM: K
+        l2x_vic[i].l2x_Sl_t = out_data[i][OUT_RAD_TEMP][0];
+
+        // albedo, VIC: fraction, CESM: fraction
+        // Note: VIC does not partition its albedo, thus all types are
+        // the same value
+        // TBD: this will be fixed in a subsequent PR
+        albedo = out_data[i][OUT_ALBEDO][0];
+
+        // albedo: direct, visible
+        l2x_vic[i].l2x_Sl_avsdr = albedo;
+
+        // albedo: direct , near-ir
+        l2x_vic[i].l2x_Sl_anidr = albedo;
+
+        // albedo: diffuse, visible
+        l2x_vic[i].l2x_Sl_avsdf = albedo;
+
+        // albedo: diffuse, near-ir
+        l2x_vic[i].l2x_Sl_anidf = albedo;
+
+        // snow height, VIC: mm, CESM: m
+        // convert to VIC units
+        l2x_vic[i].l2x_Sl_snowh = out_data[i][OUT_SWE][0] / MM_PER_M;
+
+        // net shortwave, VIC: W/m2, CESM: W/m2
+        l2x_vic[i].l2x_Fall_swnet = out_data[i][OUT_SWNET][0];
+
+        // longwave up, VIC: W/m2, CESM: W/m2
+        // adjust sign for CESM sign convention
+        l2x_vic[i].l2x_Fall_lwup = -1 *
+                                   (out_data[i][OUT_LWDOWN][0] -
+                                    out_data[i][OUT_LWNET][0]);
+
+        // turbulent heat fluxes
+        // latent heat, VIC: W/m2, CESM: W/m2
+        l2x_vic[i].l2x_Fall_lat = out_data[i][OUT_LATENT][0];
+
+        // sensible heat, VIC: W/m2, CESM: W/m2
+        l2x_vic[i].l2x_Fall_sen += -1 * out_data[i][OUT_SENSIBLE][0];
+
+        // evaporation, VIC: mm, CESM: kg m-2 s-1
+        // TO-DO should we incorporate bare soil evap?
+        l2x_vic[i].l2x_Fall_evap += -1 *
+                                    (out_data[i][OUT_EVAP][0] * MM_PER_M /
+                                     global_param.dt);
+
+        // lnd->rtm input fluxes
+        l2x_vic[i].l2x_Flrl_rofliq = out_data[i][OUT_RUNOFF][0] +
+                                     out_data[i][OUT_BASEFLOW][0] /
+                                     global_param.dt;
+
 
         // running sum to make sure we get the full grid cell
         AreaFactorSum = 0;
@@ -128,72 +198,8 @@ vic_cesm_put_data()
                 }
                 AreaFactorSum += AreaFactor;
 
-                // temperature
-                // CESM units: K
-                if (overstory && snow.snow && !(options.LAKES && IsWet)) {
-                    rad_temp = energy.Tfoliage + CONST_TKFRZ;
-                }
-                else {
-                    rad_temp = energy.Tsurf + CONST_TKFRZ;
-                }
-                l2x_vic[i].l2x_Sl_t += AreaFactor * rad_temp;
-
-                // 2m reference temperature
-                // CESM units: K
-                l2x_vic[i].l2x_Sl_tref += AreaFactor *
-                                          (force[i].air_temp[NR] + CONST_TKFRZ);
-
-                // 2m reference specific humidity
-                // CESM units: g/g
-                l2x_vic[i].l2x_Sl_qref += AreaFactor * CONST_EPS *
-                                          force[i].vp[NR] /
-                                          force[i].pressure[NR];
-
-                // Albedo Note: VIC does not partition its albedo, all returned
-                // values will be the same
-
-                // albedo: direct, visible
-                // CESM units: unitless
-                // force->shortwave is the incoming shortwave (+ down)
-                // force->NetShortAtmos net shortwave flux (+ down)
-                // SWup = force->shortwave[NR] - energy.NetShortAtmos
-                // Set the albedo to zero for the case where there is no shortwave down
-                if (force[i].shortwave[NR] > 0.) {
-                    albedo = AreaFactor *
-                             (force[i].shortwave[NR] - energy.NetShortAtmos) /
-                             force[i].shortwave[NR];
-                }
-                else {
-                    albedo = 0.;
-                }
-                l2x_vic[i].l2x_Sl_avsdr += albedo;
-
-                // albedo: direct , near-ir
-                // CESM units: unitless
-                l2x_vic[i].l2x_Sl_anidr += albedo;
-
-                // albedo: diffuse, visible
-                // CESM units: unitless
-                l2x_vic[i].l2x_Sl_avsdf += albedo;
-
-                // albedo: diffuse, near-ir
-                // CESM units: unitless
-                l2x_vic[i].l2x_Sl_anidf += albedo;
-
-                // snow height
-                // CESM units: m
-                l2x_vic[i].l2x_Sl_snowh += AreaFactor * snow.depth;
-
-                // 10m wind
-                // CESM units: m/s
-                l2x_vic[i].l2x_Sl_u10 += AreaFactor * force[i].wind[NR];
-
-                // dry deposition velocities (optional)
-                // CESM units: ?
-                // l2x_vic[i].l2x_Sl_ddvel;
-
-                // aerodynamical resistance
-                // CESM units: s/m
+                // aerodynamical resistance, VIC: s/m, CESM: s/m
+                // TO-DO: update in future PR
                 if (overstory) {
                     aero_resist = cell.aero_resist[1];
                 }
@@ -232,13 +238,13 @@ vic_cesm_put_data()
 
                 // wind stress, zonal
                 // CESM units: N m-2
-                wind_stress_x = -1 * force[i].density[NR] *
+                wind_stress_x = -1 * out_data[i][OUT_DENSITY][0] *
                                 x2l_vic[i].x2l_Sa_u / aero_resist;
                 l2x_vic[i].l2x_Fall_taux += AreaFactor * wind_stress_x;
 
                 // wind stress, meridional
                 // CESM units: N m-2
-                wind_stress_y = -1 * force[i].density[NR] *
+                wind_stress_y = -1 * out_data[i][OUT_DENSITY][0] *
                                 x2l_vic[i].x2l_Sa_v / aero_resist;
                 l2x_vic[i].l2x_Fall_tauy += AreaFactor * wind_stress_y;
 
@@ -247,72 +253,13 @@ vic_cesm_put_data()
                 wind_stress =
                     sqrt(pow(wind_stress_x, 2) + pow(wind_stress_y, 2));
                 l2x_vic[i].l2x_Sl_fv += AreaFactor *
-                                        (wind_stress / force[i].density[NR]);
-
-                // latent heat flux
-                // CESM units: W m-2
-                l2x_vic[i].l2x_Fall_lat += AreaFactor * energy.AtmosLatent;
-
-                // sensible heat flux
-                // CESM units: W m-2
-                l2x_vic[i].l2x_Fall_sen += -1 * AreaFactor *
-                                           energy.AtmosSensible;
-
-                // upward longwave heat flux
-                // CESM units: W m-2
-                l2x_vic[i].l2x_Fall_lwup += -1 * AreaFactor *
-                                            (force[i].longwave[NR] -
-                                             energy.NetLongAtmos);
-
-                // evaporation water flux
-                // CESM units: kg m-2 s-1
-                evap = 0.0;
-                for (index = 0; index < options.Nlayer; index++) {
-                    evap += cell.layer[index].evap;
-                }
-                evap += snow.vapor_flux * MM_PER_M;
-                if (HasVeg) {
-                    evap += snow.canopy_vapor_flux * MM_PER_M;
-                    evap += veg_var.canopyevap;
-                }
-                l2x_vic[i].l2x_Fall_evap += -1 * AreaFactor * evap /
-                                            global_param.dt;
-
-                // heat flux shortwave net
-                l2x_vic[i].l2x_Fall_swnet += AreaFactor *
-                                             (force[i].shortwave[NR] -
-                                              energy.NetShortAtmos);
-
-                // co2 flux **For testing set to 0
-                // l2x_vic[i].l2x_Fall_fco2_lnd;
-
-                // dust flux size bin 1
-                // l2x_vic[i].l2x_Fall_flxdst1;
-
-                // dust flux size bin 2
-                // l2x_vic[i].l2x_Fall_flxdst2;
-
-                // dust flux size bin 3
-                // l2x_vic[i].l2x_Fall_flxdst3;
-
-                // dust flux size bin 4
-                // l2x_vic[i].l2x_Fall_flxdst4;
-
-                // MEGAN fluxes
-                // l2x_vic[i].l2x_Fall_flxvoc;
-
-                // lnd->rtm input fluxes
-                l2x_vic[i].l2x_Flrl_rofliq += AreaFactor *
-                                              (cell.runoff +
-                                               cell.baseflow) / global_param.dt;
-
-                // lnd->rtm input fluxes
-                // l2x_vic[i].l2x_Flrl_rofice;
-
-                // vars set flag
-                l2x_vic[i].l2x_vars_set = true;
+                                        (wind_stress /
+                                         out_data[i][OUT_DENSITY][0]);
             }
         }
+
+        // set variables-set flag
+        l2x_vic[i].l2x_vars_set = true;
 
         if (!assert_close_double(AreaFactorSum, 1., 0., 1e-3)) {
             log_warn("AreaFactorSum (%f) is not 1",

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -123,8 +123,7 @@ vic_cesm_put_data()
         // albedo, VIC: fraction, CESM: fraction
         // Note: VIC does not partition its albedo, thus all types are
         // the same value
-        // TBD: this will be fixed in a subsequent PR
-        albedo = out_data[i][OUT_ALBEDO][0];
+        albedo = all_vars[i].gridcell_avg.avg_albedo;
 
         // albedo: direct, visible
         l2x_vic[i].l2x_Sl_avsdr = albedo;

--- a/vic/drivers/cesm/src/vic_populate_model_state.c
+++ b/vic/drivers/cesm/src/vic_populate_model_state.c
@@ -30,8 +30,8 @@
  * @brief    This function handles tasks related to populating model state.
  *****************************************************************************/
 void
-vic_populate_model_state(char *runtype_str,
-			 dmy_struct *dmy_current)
+vic_populate_model_state(char       *runtype_str,
+                         dmy_struct *dmy_current)
 {
     extern all_vars_struct *all_vars;
     extern lake_con_struct *lake_con;

--- a/vic/drivers/cesm/src/vic_populate_model_state.c
+++ b/vic/drivers/cesm/src/vic_populate_model_state.c
@@ -30,7 +30,8 @@
  * @brief    This function handles tasks related to populating model state.
  *****************************************************************************/
 void
-vic_populate_model_state(char *runtype_str)
+vic_populate_model_state(char *runtype_str,
+			 dmy_struct *dmy_current)
 {
     extern all_vars_struct *all_vars;
     extern lake_con_struct *lake_con;
@@ -69,7 +70,7 @@ vic_populate_model_state(char *runtype_str)
             // no initial state file specified - generate default state
             for (i = 0; i < local_domain.ncells_active; i++) {
                 generate_default_state(&(all_vars[i]), &(soil_con[i]),
-                                       veg_con[i]);
+                                       veg_con[i], dmy_current);
                 if (options.LAKES) {
                     generate_default_lake_state(&(all_vars[i]), &(soil_con[i]),
                                                 lake_con[i]);

--- a/vic/drivers/classic/include/vic_driver_classic.h
+++ b/vic/drivers/classic/include/vic_driver_classic.h
@@ -111,8 +111,7 @@ void vic_force(force_data_struct *, dmy_struct *, FILE **, veg_con_struct *,
                veg_hist_struct **, soil_con_struct *);
 void vic_populate_model_state(all_vars_struct *, filep_struct, size_t,
                               soil_con_struct *, veg_con_struct *,
-                              lake_con_struct,
-			      dmy_struct *);
+                              lake_con_struct, dmy_struct *);
 void write_data(stream_struct *streams);
 void write_header(stream_struct **streams, dmy_struct *dmy);
 void write_model_state(all_vars_struct *, int, int, filep_struct *,

--- a/vic/drivers/classic/include/vic_driver_classic.h
+++ b/vic/drivers/classic/include/vic_driver_classic.h
@@ -111,7 +111,8 @@ void vic_force(force_data_struct *, dmy_struct *, FILE **, veg_con_struct *,
                veg_hist_struct **, soil_con_struct *);
 void vic_populate_model_state(all_vars_struct *, filep_struct, size_t,
                               soil_con_struct *, veg_con_struct *,
-                              lake_con_struct);
+                              lake_con_struct,
+			      dmy_struct *);
 void write_data(stream_struct *streams);
 void write_header(stream_struct **streams, dmy_struct *dmy);
 void write_model_state(all_vars_struct *, int, int, filep_struct *,

--- a/vic/drivers/classic/src/vic_classic.c
+++ b/vic/drivers/classic/src/vic_classic.c
@@ -225,7 +225,7 @@ main(int   argc,
             **************************************************/
 
             vic_populate_model_state(&all_vars, filep, soil_con.gridcel,
-                                     &soil_con, veg_con, lake_con, &(dmy[0]);
+                                     &soil_con, veg_con, lake_con, &(dmy[0]));
 
             /** Initialize the storage terms in the water and energy balances **/
             initialize_save_data(&all_vars, &force[0], &soil_con, veg_con,

--- a/vic/drivers/classic/src/vic_classic.c
+++ b/vic/drivers/classic/src/vic_classic.c
@@ -225,7 +225,7 @@ main(int   argc,
             **************************************************/
 
             vic_populate_model_state(&all_vars, filep, soil_con.gridcel,
-                                     &soil_con, veg_con, lake_con);
+                                     &soil_con, veg_con, lake_con, &(dmy[0]);
 
             /** Initialize the storage terms in the water and energy balances **/
             initialize_save_data(&all_vars, &force[0], &soil_con, veg_con,

--- a/vic/drivers/classic/src/vic_populate_model_state.c
+++ b/vic/drivers/classic/src/vic_populate_model_state.c
@@ -44,7 +44,8 @@ vic_populate_model_state(all_vars_struct *all_vars,
                          size_t           cellnum,
                          soil_con_struct *soil_con,
                          veg_con_struct  *veg_con,
-                         lake_con_struct  lake_con)
+                         lake_con_struct  lake_con,
+			 dmy_struct      *dmy_current)
 {
     extern option_struct options;
 
@@ -87,7 +88,7 @@ vic_populate_model_state(all_vars_struct *all_vars,
     }
     else {
         // else generate a default state
-        generate_default_state(all_vars, soil_con, veg_con);
+        generate_default_state(all_vars, soil_con, veg_con, dmy_current);
         if (options.LAKES) {
             generate_default_lake_state(all_vars, soil_con, lake_con);
         }

--- a/vic/drivers/classic/src/vic_populate_model_state.c
+++ b/vic/drivers/classic/src/vic_populate_model_state.c
@@ -45,7 +45,7 @@ vic_populate_model_state(all_vars_struct *all_vars,
                          soil_con_struct *soil_con,
                          veg_con_struct  *veg_con,
                          lake_con_struct  lake_con,
-			 dmy_struct      *dmy_current)
+                         dmy_struct      *dmy_current)
 {
     extern option_struct options;
 

--- a/vic/drivers/image/include/vic_driver_image.h
+++ b/vic/drivers/image/include/vic_driver_image.h
@@ -39,6 +39,6 @@ void vic_force(void);
 void vic_image_init(void);
 void vic_image_finalize();
 void vic_image_start(void);
-void vic_populate_model_state(void);
+void vic_populate_model_state(dmy_struct *dmy_current);
 
 #endif

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -115,7 +115,7 @@ main(int    argc,
     vic_image_init();
 
     // populate model state, either using a cold start or from a restart file
-    vic_populate_model_state();
+    vic_populate_model_state(&(dmy[0]);
 
     // initialize output structures
     vic_init_output(&(dmy[0]));

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -115,7 +115,7 @@ main(int    argc,
     vic_image_init();
 
     // populate model state, either using a cold start or from a restart file
-    vic_populate_model_state(&(dmy[0]);
+    vic_populate_model_state(&(dmy[0]));
 
     // initialize output structures
     vic_init_output(&(dmy[0]));

--- a/vic/drivers/image/src/vic_populate_model_state.c
+++ b/vic/drivers/image/src/vic_populate_model_state.c
@@ -36,7 +36,7 @@
  * @brief    This function handles tasks related to populating model state.
  *****************************************************************************/
 void
-vic_populate_model_state(void)
+vic_populate_model_state(dmy_struct *dmy_current)
 {
     extern all_vars_struct *all_vars;
     extern lake_con_struct *lake_con;
@@ -54,7 +54,7 @@ vic_populate_model_state(void)
     else {
         // else generate a default state
         for (i = 0; i < local_domain.ncells_active; i++) {
-            generate_default_state(&(all_vars[i]), &(soil_con[i]), veg_con[i]);
+            generate_default_state(&(all_vars[i]), &(soil_con[i]), veg_con[i], dmy_current);
             if (options.LAKES) {
                 generate_default_lake_state(&(all_vars[i]), &(soil_con[i]),
                                             lake_con[i]);

--- a/vic/drivers/image/src/vic_populate_model_state.c
+++ b/vic/drivers/image/src/vic_populate_model_state.c
@@ -54,7 +54,8 @@ vic_populate_model_state(dmy_struct *dmy_current)
     else {
         // else generate a default state
         for (i = 0; i < local_domain.ncells_active; i++) {
-            generate_default_state(&(all_vars[i]), &(soil_con[i]), veg_con[i], dmy_current);
+            generate_default_state(&(all_vars[i]), &(soil_con[i]), veg_con[i],
+                                   dmy_current);
             if (options.LAKES) {
                 generate_default_lake_state(&(all_vars[i]), &(soil_con[i]),
                                             lake_con[i]);

--- a/vic/drivers/shared_all/include/vic_driver_shared_all.h
+++ b/vic/drivers/shared_all/include/vic_driver_shared_all.h
@@ -629,7 +629,7 @@ void free_out_data(size_t ngridcells, double ***out_data);
 void free_streams(stream_struct **streams);
 void free_vegcon(veg_con_struct **veg_con);
 void generate_default_state(all_vars_struct *, soil_con_struct *,
-                            veg_con_struct *);
+                            veg_con_struct *, dmy_struct *);
 void generate_default_lake_state(all_vars_struct *, soil_con_struct *,
                                  lake_con_struct);
 void get_default_nstreams_nvars(size_t *nstreams, size_t nvars[]);

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -35,7 +35,7 @@ void
 generate_default_state(all_vars_struct *all_vars,
                        soil_con_struct *soil_con,
                        veg_con_struct  *veg_con,
-		       dmy_struct      *dmy_current)
+                       dmy_struct      *dmy_current)
 {
     extern option_struct     options;
     extern parameters_struct param;

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -151,7 +151,6 @@ generate_default_state(all_vars_struct *all_vars,
             }
             else {
 		// bare soil class, use bare soil albedo
-		debug("param.ALBEDO_BARE_SOIL is %f", param.ALBEDO_BARE_SOIL);
 		albedo_sum += AreaFactor * param.ALBEDO_BARE_SOIL;    
 	    }
         }

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -36,9 +36,10 @@ generate_default_state(all_vars_struct *all_vars,
                        soil_con_struct *soil_con,
                        veg_con_struct  *veg_con)
 {
+    extern size_t            current;
     extern option_struct     options;
     extern parameters_struct param;
-    extern dmy_struct        dmy_current;
+    extern dmy_struct       *dmy;
 
     size_t                   Nveg;
     size_t                   veg;
@@ -148,7 +149,7 @@ generate_default_state(all_vars_struct *all_vars,
                 // cold start, so using climatological albedo for all veg classes
                 // except for bare soil
                 albedo_sum += (AreaFactor *
-                               veg_con[veg].albedo[dmy_current.month - 1]);
+                               veg_con[veg].albedo[dmy[current].month - 1]);
             }
             else {
                 // bare soil class, use bare soil albedo

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -34,12 +34,11 @@
 void
 generate_default_state(all_vars_struct *all_vars,
                        soil_con_struct *soil_con,
-                       veg_con_struct  *veg_con)
+                       veg_con_struct  *veg_con,
+		       dmy_struct      *dmy_current)
 {
-    extern size_t            current;
     extern option_struct     options;
     extern parameters_struct param;
-    extern dmy_struct       *dmy;
 
     size_t                   Nveg;
     size_t                   veg;
@@ -149,7 +148,7 @@ generate_default_state(all_vars_struct *all_vars,
                 // cold start, so using climatological albedo for all veg classes
                 // except for bare soil
                 albedo_sum += (AreaFactor *
-                               veg_con[veg].albedo[dmy[current].month - 1]);
+                               veg_con[veg].albedo[dmy_current->month - 1]);
             }
             else {
                 // bare soil class, use bare soil albedo

--- a/vic/drivers/shared_all/src/generate_default_state.c
+++ b/vic/drivers/shared_all/src/generate_default_state.c
@@ -148,12 +148,12 @@ generate_default_state(all_vars_struct *all_vars,
                 // cold start, so using climatological albedo for all veg classes
                 // except for bare soil
                 albedo_sum += (AreaFactor *
-                              veg_con[veg].albedo[dmy_current.month - 1]);
+                               veg_con[veg].albedo[dmy_current.month - 1]);
             }
             else {
-		// bare soil class, use bare soil albedo
-		albedo_sum += AreaFactor * param.ALBEDO_BARE_SOIL;    
-	    }
+                // bare soil class, use bare soil albedo
+                albedo_sum += AreaFactor * param.ALBEDO_BARE_SOIL;
+            }
         }
     }
     all_vars->gridcell_avg.avg_albedo = albedo_sum;

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -49,9 +49,10 @@ double calc_atmos_energy_bal(double, double, double, double, double, double,
                              double, double *, double *, double *, double *,
                              double *, double *, bool *, unsigned int*);
 double calc_density(double);
-void calc_gridcell_avg_albedo(double *, double, size_t, bool, energy_bal_struct **,
-			      veg_var_struct **, snow_data_struct **,
-                              veg_con_struct *, soil_con_struct *);
+void calc_gridcell_avg_albedo(double *, double, size_t, bool,
+                              energy_bal_struct **, veg_var_struct **,
+                              snow_data_struct **, veg_con_struct *,
+                              soil_con_struct *);
 double calc_latent_heat_of_sublimation(double temp);
 double calc_latent_heat_of_vaporization(double temp);
 int calc_layer_average_thermal_props(energy_bal_struct *, layer_data_struct *,

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -49,7 +49,8 @@ double calc_atmos_energy_bal(double, double, double, double, double, double,
                              double, double *, double *, double *, double *,
                              double *, double *, bool *, unsigned int*);
 double calc_density(double);
-void calc_gridcell_avg_albedo(double *, double, size_t, energy_bal_struct **,
+void calc_gridcell_avg_albedo(double *, double, size_t, bool, energy_bal_struct **,
+			      veg_var_struct **, snow_data_struct **,
                               veg_con_struct *, soil_con_struct *);
 double calc_latent_heat_of_sublimation(double temp);
 double calc_latent_heat_of_vaporization(double temp);

--- a/vic/vic_run/include/vic_run.h
+++ b/vic/vic_run/include/vic_run.h
@@ -50,9 +50,8 @@ double calc_atmos_energy_bal(double, double, double, double, double, double,
                              double *, double *, bool *, unsigned int*);
 double calc_density(double);
 void calc_gridcell_avg_albedo(double *, double, size_t, bool,
-                              energy_bal_struct **, veg_var_struct **,
-                              snow_data_struct **, veg_con_struct *,
-                              soil_con_struct *);
+                              energy_bal_struct **, snow_data_struct **, 
+			      veg_con_struct *, soil_con_struct *);
 double calc_latent_heat_of_sublimation(double temp);
 double calc_latent_heat_of_vaporization(double temp);
 int calc_layer_average_thermal_props(energy_bal_struct *, layer_data_struct *,

--- a/vic/vic_run/src/calc_gridcell_avg_albedo.c
+++ b/vic/vic_run/src/calc_gridcell_avg_albedo.c
@@ -36,23 +36,23 @@ void
 calc_gridcell_avg_albedo(double             *albedo,
                          double              shortwave,
                          size_t              Nveg,
-			 bool                overstory,
+                         bool                overstory,
                          energy_bal_struct **energy,
-			 veg_var_struct    **veg_var,
-			 snow_data_struct  **snow,
+                         veg_var_struct    **veg_var,
+                         snow_data_struct  **snow,
                          veg_con_struct     *veg_con,
                          soil_con_struct    *soil_con)
 {
-    extern option_struct options;
+    extern option_struct     options;
     extern parameters_struct param;
-    size_t               veg;
-    size_t               band;
-    double               Cv;
-    double               AreaFactor;
-    double               TreeAdjustFactor = 1.;
-    double               lakefactor = 1;
-    double               swnet;
-    bool                 HasVeg;
+    size_t                   veg;
+    size_t                   band;
+    double                   Cv;
+    double                   AreaFactor;
+    double                   TreeAdjustFactor = 1.;
+    double                   lakefactor = 1;
+    double                   swnet;
+    bool                     HasVeg;
 
     swnet = 0;
 
@@ -72,30 +72,32 @@ calc_gridcell_avg_albedo(double             *albedo,
 
     // compute gridcell-averaged albedo using average shortwave
     if (shortwave > 0) {
-    	// use average shortwave for albedo calculation
-    	*albedo = 1. - (swnet / shortwave);
+        // use average shortwave for albedo calculation
+        *albedo = 1. - (swnet / shortwave);
     }
     else {
-    	// use vegetation, snow or bare soil albedo
-    	for (veg = 0; veg <= Nveg; veg++) { 
-	    Cv = veg_con[veg].Cv;
-	    if (Cv > 0) {
-	        for (band = 0; band < options.SNOW_BAND; band++) {
-	            if (soil_con->AreaFract[band] > 0.) {
-		        // TO-DO: account for treeline and lake factors 
-		        AreaFactor = (Cv * soil_con->AreaFract[band] * 
-				      TreeAdjustFactor * lakefactor);
-		        if (snow[veg][band].snow && overstory) {
-		            // use snow canopy albedo
-			    *albedo += AreaFactor * energy[veg][band].AlbedoOver;
-		        }
-			else {
-			    // use surface albedo
-			    *albedo += AreaFactor * energy[veg][band].AlbedoUnder;
-			}
-		    }
-		}
-	    }
-	}
+        // use vegetation, snow or bare soil albedo
+        for (veg = 0; veg <= Nveg; veg++) {
+            Cv = veg_con[veg].Cv;
+            if (Cv > 0) {
+                for (band = 0; band < options.SNOW_BAND; band++) {
+                    if (soil_con->AreaFract[band] > 0.) {
+                        // TO-DO: account for treeline and lake factors
+                        AreaFactor = (Cv * soil_con->AreaFract[band] *
+                                      TreeAdjustFactor * lakefactor);
+                        if (snow[veg][band].snow && overstory) {
+                            // use snow canopy albedo
+                            *albedo += AreaFactor *
+                                       energy[veg][band].AlbedoOver;
+                        }
+                        else {
+                            // use surface albedo
+                            *albedo += AreaFactor *
+                                       energy[veg][band].AlbedoUnder;
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/vic/vic_run/src/calc_gridcell_avg_albedo.c
+++ b/vic/vic_run/src/calc_gridcell_avg_albedo.c
@@ -38,7 +38,6 @@ calc_gridcell_avg_albedo(double             *albedo,
                          size_t              Nveg,
                          bool                overstory,
                          energy_bal_struct **energy,
-                         veg_var_struct    **veg_var,
                          snow_data_struct  **snow,
                          veg_con_struct     *veg_con,
                          soil_con_struct    *soil_con)
@@ -52,9 +51,9 @@ calc_gridcell_avg_albedo(double             *albedo,
     double                   TreeAdjustFactor = 1.;
     double                   lakefactor = 1;
     double                   swnet;
-    bool                     HasVeg;
 
     swnet = 0;
+    *albedo = 0;
 
     for (veg = 0; veg <= Nveg; veg++) {
         Cv = veg_con[veg].Cv;

--- a/vic/vic_run/src/vic_run.c
+++ b/vic/vic_run/src/vic_run.c
@@ -384,8 +384,8 @@ vic_run(force_data_struct   *force,
 
     // Compute gridcell-averaged albedo
     calc_gridcell_avg_albedo(&all_vars->gridcell_avg.avg_albedo,
-                             force->shortwave[NR], Nveg, overstory, 
-			     energy, veg_var, snow,
+                             force->shortwave[NR], Nveg, overstory,
+                             energy, veg_var, snow,
                              veg_con, soil_con);
 
     /****************************

--- a/vic/vic_run/src/vic_run.c
+++ b/vic/vic_run/src/vic_run.c
@@ -384,7 +384,8 @@ vic_run(force_data_struct   *force,
 
     // Compute gridcell-averaged albedo
     calc_gridcell_avg_albedo(&all_vars->gridcell_avg.avg_albedo,
-                             force->shortwave[NR], Nveg, energy,
+                             force->shortwave[NR], Nveg, overstory, 
+			     energy, veg_var, snow,
                              veg_con, soil_con);
 
     /****************************

--- a/vic/vic_run/src/vic_run.c
+++ b/vic/vic_run/src/vic_run.c
@@ -385,8 +385,7 @@ vic_run(force_data_struct   *force,
     // Compute gridcell-averaged albedo
     calc_gridcell_avg_albedo(&all_vars->gridcell_avg.avg_albedo,
                              force->shortwave[NR], Nveg, overstory,
-                             energy, veg_var, snow,
-                             veg_con, soil_con);
+                             energy, snow, veg_con, soil_con);
 
     /****************************
        Run Lake Model


### PR DESCRIPTION
- [ ] ~~closes #xxx~~
- [x] tests passed
- [ ] ~~new tests added~~
- [ ] ~~science test figures~~
- [x] ran uncrustify prior to final commit
- [X] ReleaseNotes entry

This quick PR is a follow-up to #712 and #710 so that the `cesm_put_data.c` routine in the CESM driver passes gridcell-averaged albedo to WRF. 
