### PR TITLE
fixes mistake in comment for veg and bare soil albedos

### DIFF
--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -222,12 +222,13 @@ vic_cesm_put_data()
                     roughness = soil_con[i].snow_rough;
                 }
                 else if (HasVeg) {
-                    // bare soil roughness
+                    // vegetation roughness
                     roughness =
                         veg_lib[i][veg_con[i][veg].veg_class].roughness[
                             dmy_current.month - 1];
                 }
                 else {
+                    // bare soil roughness
                     roughness = soil_con[i].rough;
                 }
                 if (roughness < DBL_EPSILON) {


### PR DESCRIPTION
This PR updates the comments for vegetation and bare soil albedos in the `cesm_put_data.c` routine. Before this, they were reversed and thus confusing.  

- [ ] ~~closes #xxx~~
- [X] tests passed
- [ ] ~~new tests added~~
- [ ] ~~science test figures~~
- [X] ran uncrustify prior to final commit
- [ ] ~~ReleaseNotes entry~~
