### PR TITLE
Feature/fix remaining coupler fields

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -69,7 +69,11 @@ To check which release of VIC you are running:
 
     [GH#732] (https://github.com/UW-Hydro/VIC/pull/732)
  
-        Updates the cesm_put_data.c routine in the CESM driver to include the correct units for sensible heat flux and updates the rofliq calculation to be correct (previously only OUT_BASEFLOW was being divided by global_param.dt).  
+        Updates the cesm_put_data.c routine in the CESM driver to include the correct units for sensible heat flux and updates the rofliq calculation to be correct (previously only OUT_BASEFLOW was being divided by global_param.dt). 
+
+    [GH#734] (https://github.com/UW-Hydro/VIC/pull/734) 
+
+        Updates the cesm_put_data.c routine in the CESM driver to include the correct signs for turbulent heat fluxes and evaporation. Previously we had switched the signs to agree with the image driver and they should instead be in accordance with the sign conventions for coupled models, which differ from those of land surface models. Also, eliminate populating the `l2x_Sl_ram1` field with aero_resist to agree with the VIC 4 implementation in RASM. 
 
 3. Speed up NetCDF operations in the image/CESM drivers ([GH#684](https://github.com/UW-Hydro/VIC/pull/684))
 

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -151,7 +151,7 @@ vic_cesm_put_data()
                                     out_data[i][OUT_LWNET][0]);
 
         // turbulent heat fluxes
-        // Note: both are the opposite sign from image driver 
+        // Note: both are the opposite sign from image driver
         // in accordance with the sign convention for coupled models
         // latent heat, VIC: W/m2, CESM: W/m2
         l2x_vic[i].l2x_Fall_lat = -1 * out_data[i][OUT_LATENT][0];
@@ -210,58 +210,59 @@ vic_cesm_put_data()
                     log_warn("aero_resist (%f) is < %f", aero_resist,
                              DBL_EPSILON);
                     aero_resist = param.HUGE_RESIST;
-              
 
-                // log z0
-                // CESM units: m
-                if (snow.snow) {
-                    // snow roughness
-                    roughness = soil_con[i].snow_rough;
-                }
-                else if (HasVeg) {
-                    // vegetation roughness
-                    roughness =
-                        veg_lib[i][veg_con[i][veg].veg_class].roughness[
-                            dmy_current.month - 1];
-                }
-                else {
-                    // bare soil roughness
-                    roughness = soil_con[i].rough;
-                }
-                if (roughness < DBL_EPSILON) {
-                    log_warn("roughness (%f) is < %f", roughness, DBL_EPSILON);
-                    roughness = DBL_EPSILON;
-                }
-                l2x_vic[i].l2x_Sl_logz0 += AreaFactor * log(roughness);
 
-                // wind stress, zonal
-                // CESM units: N m-2
-                wind_stress_x = -1 * out_data[i][OUT_DENSITY][0] *
-                                x2l_vic[i].x2l_Sa_u / aero_resist;
-                l2x_vic[i].l2x_Fall_taux += AreaFactor * wind_stress_x;
+                    // log z0
+                    // CESM units: m
+                    if (snow.snow) {
+                        // snow roughness
+                        roughness = soil_con[i].snow_rough;
+                    }
+                    else if (HasVeg) {
+                        // vegetation roughness
+                        roughness =
+                            veg_lib[i][veg_con[i][veg].veg_class].roughness[
+                                dmy_current.month - 1];
+                    }
+                    else {
+                        // bare soil roughness
+                        roughness = soil_con[i].rough;
+                    }
+                    if (roughness < DBL_EPSILON) {
+                        log_warn("roughness (%f) is < %f", roughness,
+                                 DBL_EPSILON);
+                        roughness = DBL_EPSILON;
+                    }
+                    l2x_vic[i].l2x_Sl_logz0 += AreaFactor * log(roughness);
 
-                // wind stress, meridional
-                // CESM units: N m-2
-                wind_stress_y = -1 * out_data[i][OUT_DENSITY][0] *
-                                x2l_vic[i].x2l_Sa_v / aero_resist;
-                l2x_vic[i].l2x_Fall_tauy += AreaFactor * wind_stress_y;
+                    // wind stress, zonal
+                    // CESM units: N m-2
+                    wind_stress_x = -1 * out_data[i][OUT_DENSITY][0] *
+                                    x2l_vic[i].x2l_Sa_u / aero_resist;
+                    l2x_vic[i].l2x_Fall_taux += AreaFactor * wind_stress_x;
 
-                // friction velocity
-                // CESM units: m s-1
-                wind_stress =
-                    sqrt(pow(wind_stress_x, 2) + pow(wind_stress_y, 2));
-                l2x_vic[i].l2x_Sl_fv += AreaFactor *
-                                        (wind_stress /
-                                         out_data[i][OUT_DENSITY][0]);
+                    // wind stress, meridional
+                    // CESM units: N m-2
+                    wind_stress_y = -1 * out_data[i][OUT_DENSITY][0] *
+                                    x2l_vic[i].x2l_Sa_v / aero_resist;
+                    l2x_vic[i].l2x_Fall_tauy += AreaFactor * wind_stress_y;
+
+                    // friction velocity
+                    // CESM units: m s-1
+                    wind_stress =
+                        sqrt(pow(wind_stress_x, 2) + pow(wind_stress_y, 2));
+                    l2x_vic[i].l2x_Sl_fv += AreaFactor *
+                                            (wind_stress /
+                                             out_data[i][OUT_DENSITY][0]);
+                }
+            }
+
+            // set variables-set flag
+            l2x_vic[i].l2x_vars_set = true;
+
+            if (!assert_close_double(AreaFactorSum, 1., 0., 1e-3)) {
+                log_warn("AreaFactorSum (%f) is not 1",
+                         AreaFactorSum);
             }
         }
-
-        // set variables-set flag
-        l2x_vic[i].l2x_vars_set = true;
-
-        if (!assert_close_double(AreaFactorSum, 1., 0., 1e-3)) {
-            log_warn("AreaFactorSum (%f) is not 1",
-                     AreaFactorSum);
-        }
     }
-}

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -151,7 +151,7 @@ vic_cesm_put_data()
                                     out_data[i][OUT_LWNET][0]);
 
         // turbulent heat fluxes
-        // Note: both are the opposite sign from image driver 
+        // Note: both are the opposite sign from image driver
         // in accordance with the sign convention for coupled models
         // latent heat, VIC: W/m2, CESM: W/m2
         l2x_vic[i].l2x_Fall_lat = -1 * out_data[i][OUT_LATENT][0];

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -151,6 +151,8 @@ vic_cesm_put_data()
                                     out_data[i][OUT_LWNET][0]);
 
         // turbulent heat fluxes
+        // Note: both are the opposite sign from image driver 
+        // in accordance with the sign convention for coupled models
         // latent heat, VIC: W/m2, CESM: W/m2
         l2x_vic[i].l2x_Fall_lat = -1 * out_data[i][OUT_LATENT][0];
 

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -152,13 +152,13 @@ vic_cesm_put_data()
 
         // turbulent heat fluxes
         // latent heat, VIC: W/m2, CESM: W/m2
-        l2x_vic[i].l2x_Fall_lat = out_data[i][OUT_LATENT][0];
+        l2x_vic[i].l2x_Fall_lat = -1 * out_data[i][OUT_LATENT][0];
 
         // sensible heat, VIC: W/m2, CESM: W/m2
-        l2x_vic[i].l2x_Fall_sen += out_data[i][OUT_SENSIBLE][0];
+        l2x_vic[i].l2x_Fall_sen += -1 * out_data[i][OUT_SENSIBLE][0];
 
         // evaporation, VIC: mm, CESM: kg m-2 s-1
-        l2x_vic[i].l2x_Fall_evap += out_data[i][OUT_EVAP][0] /
+        l2x_vic[i].l2x_Fall_evap += -1 * out_data[i][OUT_EVAP][0] /
                                     global_param.dt;
 
         // lnd->rtm input fluxes
@@ -208,9 +208,7 @@ vic_cesm_put_data()
                     log_warn("aero_resist (%f) is < %f", aero_resist,
                              DBL_EPSILON);
                     aero_resist = param.HUGE_RESIST;
-                }
-
-                l2x_vic[i].l2x_Sl_ram1 += AreaFactor * aero_resist;
+              
 
                 // log z0
                 // CESM units: m

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -151,7 +151,7 @@ vic_cesm_put_data()
                                     out_data[i][OUT_LWNET][0]);
 
         // turbulent heat fluxes
-        // Note: both are the opposite sign from image driver
+        // Note: both are the opposite sign from image driver 
         // in accordance with the sign convention for coupled models
         // latent heat, VIC: W/m2, CESM: W/m2
         l2x_vic[i].l2x_Fall_lat = -1 * out_data[i][OUT_LATENT][0];
@@ -210,59 +210,58 @@ vic_cesm_put_data()
                     log_warn("aero_resist (%f) is < %f", aero_resist,
                              DBL_EPSILON);
                     aero_resist = param.HUGE_RESIST;
+              
 
-
-                    // log z0
-                    // CESM units: m
-                    if (snow.snow) {
-                        // snow roughness
-                        roughness = soil_con[i].snow_rough;
-                    }
-                    else if (HasVeg) {
-                        // vegetation roughness
-                        roughness =
-                            veg_lib[i][veg_con[i][veg].veg_class].roughness[
-                                dmy_current.month - 1];
-                    }
-                    else {
-                        // bare soil roughness
-                        roughness = soil_con[i].rough;
-                    }
-                    if (roughness < DBL_EPSILON) {
-                        log_warn("roughness (%f) is < %f", roughness,
-                                 DBL_EPSILON);
-                        roughness = DBL_EPSILON;
-                    }
-                    l2x_vic[i].l2x_Sl_logz0 += AreaFactor * log(roughness);
-
-                    // wind stress, zonal
-                    // CESM units: N m-2
-                    wind_stress_x = -1 * out_data[i][OUT_DENSITY][0] *
-                                    x2l_vic[i].x2l_Sa_u / aero_resist;
-                    l2x_vic[i].l2x_Fall_taux += AreaFactor * wind_stress_x;
-
-                    // wind stress, meridional
-                    // CESM units: N m-2
-                    wind_stress_y = -1 * out_data[i][OUT_DENSITY][0] *
-                                    x2l_vic[i].x2l_Sa_v / aero_resist;
-                    l2x_vic[i].l2x_Fall_tauy += AreaFactor * wind_stress_y;
-
-                    // friction velocity
-                    // CESM units: m s-1
-                    wind_stress =
-                        sqrt(pow(wind_stress_x, 2) + pow(wind_stress_y, 2));
-                    l2x_vic[i].l2x_Sl_fv += AreaFactor *
-                                            (wind_stress /
-                                             out_data[i][OUT_DENSITY][0]);
+                // log z0
+                // CESM units: m
+                if (snow.snow) {
+                    // snow roughness
+                    roughness = soil_con[i].snow_rough;
                 }
-            }
+                else if (HasVeg) {
+                    // vegetation roughness
+                    roughness =
+                        veg_lib[i][veg_con[i][veg].veg_class].roughness[
+                            dmy_current.month - 1];
+                }
+                else {
+                    // bare soil roughness
+                    roughness = soil_con[i].rough;
+                }
+                if (roughness < DBL_EPSILON) {
+                    log_warn("roughness (%f) is < %f", roughness, DBL_EPSILON);
+                    roughness = DBL_EPSILON;
+                }
+                l2x_vic[i].l2x_Sl_logz0 += AreaFactor * log(roughness);
 
-            // set variables-set flag
-            l2x_vic[i].l2x_vars_set = true;
+                // wind stress, zonal
+                // CESM units: N m-2
+                wind_stress_x = -1 * out_data[i][OUT_DENSITY][0] *
+                                x2l_vic[i].x2l_Sa_u / aero_resist;
+                l2x_vic[i].l2x_Fall_taux += AreaFactor * wind_stress_x;
 
-            if (!assert_close_double(AreaFactorSum, 1., 0., 1e-3)) {
-                log_warn("AreaFactorSum (%f) is not 1",
-                         AreaFactorSum);
+                // wind stress, meridional
+                // CESM units: N m-2
+                wind_stress_y = -1 * out_data[i][OUT_DENSITY][0] *
+                                x2l_vic[i].x2l_Sa_v / aero_resist;
+                l2x_vic[i].l2x_Fall_tauy += AreaFactor * wind_stress_y;
+
+                // friction velocity
+                // CESM units: m s-1
+                wind_stress =
+                    sqrt(pow(wind_stress_x, 2) + pow(wind_stress_y, 2));
+                l2x_vic[i].l2x_Sl_fv += AreaFactor *
+                                        (wind_stress /
+                                         out_data[i][OUT_DENSITY][0]);
             }
         }
+
+        // set variables-set flag
+        l2x_vic[i].l2x_vars_set = true;
+
+        if (!assert_close_double(AreaFactorSum, 1., 0., 1e-3)) {
+            log_warn("AreaFactorSum (%f) is not 1",
+                     AreaFactorSum);
+        }
     }
+}

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -210,7 +210,7 @@ vic_cesm_put_data()
                     log_warn("aero_resist (%f) is < %f", aero_resist,
                              DBL_EPSILON);
                     aero_resist = param.HUGE_RESIST;
-              
+                }
 
                 // log z0
                 // CESM units: m


### PR DESCRIPTION
This PR fixes the signs for evaporation (`l2x_Fall_evap`), latent heat (`l2x_Fall_lat`) and sensible heat (`l2x_Fall_sen`). Sign conventions now agree with those for coupled models (before we'd switched them back to agree with the image driver, which was incorrect). 

- [ ] ~closes #xxx~
- [x] tests passed
- [ ] ~new tests added~
- [ ] ~science test figures~
- [X] ran uncrustify prior to final commit
- [X] ReleaseNotes entry
