### PR TITLE
Feature/fix taux tauy fv

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -75,6 +75,10 @@ To check which release of VIC you are running:
 
         Updates the cesm_put_data.c routine in the CESM driver to include the correct signs for turbulent heat fluxes and evaporation. Previously we had switched the signs to agree with the image driver and they should instead be in accordance with the sign conventions for coupled models, which differ from those of land surface models. Also, eliminate populating the `l2x_Sl_ram1` field with aero_resist to agree with the VIC 4 implementation in RASM. 
 
+    [GH#739] (https://github.com/UW-Hydro/VIC/pull/739)
+
+        Updates the cesm_put_data.c routine in the CESM driver to include the correct signs for the wind stresses and fixes a bug in calculating friction velocity (previously it was missing a square root). 
+
 3. Speed up NetCDF operations in the image/CESM drivers ([GH#684](https://github.com/UW-Hydro/VIC/pull/684))
 
     These changes speed up image driver initialization, forcing reads, and history writes by only opening and closing each input netCDF file once.

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -251,7 +251,7 @@ vic_cesm_put_data()
                     sqrt(pow(wind_stress_x, 2) + pow(wind_stress_y, 2));
                 l2x_vic[i].l2x_Sl_fv += AreaFactor *
                                         sqrt(wind_stress /
-                                         out_data[i][OUT_DENSITY][0]);
+                                             out_data[i][OUT_DENSITY][0]);
             }
         }
 

--- a/vic/drivers/cesm/src/cesm_put_data.c
+++ b/vic/drivers/cesm/src/cesm_put_data.c
@@ -198,7 +198,6 @@ vic_cesm_put_data()
                 AreaFactorSum += AreaFactor;
 
                 // aerodynamical resistance, VIC: s/m, CESM: s/m
-                // TO-DO: update in future PR
                 if (overstory) {
                     aero_resist = cell.aero_resist[1];
                 }
@@ -236,13 +235,13 @@ vic_cesm_put_data()
 
                 // wind stress, zonal
                 // CESM units: N m-2
-                wind_stress_x = -1 * out_data[i][OUT_DENSITY][0] *
+                wind_stress_x = out_data[i][OUT_DENSITY][0] *
                                 x2l_vic[i].x2l_Sa_u / aero_resist;
                 l2x_vic[i].l2x_Fall_taux += AreaFactor * wind_stress_x;
 
                 // wind stress, meridional
                 // CESM units: N m-2
-                wind_stress_y = -1 * out_data[i][OUT_DENSITY][0] *
+                wind_stress_y = out_data[i][OUT_DENSITY][0] *
                                 x2l_vic[i].x2l_Sa_v / aero_resist;
                 l2x_vic[i].l2x_Fall_tauy += AreaFactor * wind_stress_y;
 
@@ -251,7 +250,7 @@ vic_cesm_put_data()
                 wind_stress =
                     sqrt(pow(wind_stress_x, 2) + pow(wind_stress_y, 2));
                 l2x_vic[i].l2x_Sl_fv += AreaFactor *
-                                        (wind_stress /
+                                        sqrt(wind_stress /
                                          out_data[i][OUT_DENSITY][0]);
             }
         }


### PR DESCRIPTION
- [X] closes #737 and #738 
- [x] tests passed
- [ ] ~new tests added~
- [ ] ~science test figures~
- [X] ran uncrustify prior to final commit
- [x] ReleaseNotes entry

Here are some figures from fully-coupled RASM runs, from the timestep just before the debug walltime was up, showing differences between RASM with VIC 4, the develop branch and this branch (labeled as "VIC 5 Bug Fix"). Colorbars are constrained for each to show differences. 

In order: `l2x_Fall_taux` (zonal wind stress), `l2x_Fall_tauy` (meridional wind stress), `l2x_Sl_fv` (friction velocity): 

![image](https://user-images.githubusercontent.com/5017308/29642330-11e205aa-881d-11e7-9eb3-d26a53443fea.png)

![image](https://user-images.githubusercontent.com/5017308/29642336-16d2ee30-881d-11e7-8750-86203eacdc2e.png)

![image](https://user-images.githubusercontent.com/5017308/29642341-1be7731e-881d-11e7-9af6-8127c56cf1ff.png)
