### PR TITLE
remove redundant definition of frozen soils max iteration number

### DIFF
--- a/vic/drivers/shared_all/src/initialize_parameters.c
+++ b/vic/drivers/shared_all/src/initialize_parameters.c
@@ -227,7 +227,4 @@ initialize_parameters()
     param.ROOT_BRENT_MAXITER = 1000;
     param.ROOT_BRENT_TSTEP = 10;
     param.ROOT_BRENT_T = 1.0e-7;
-
-    // Frozen Soil Parameters
-    param.FROZEN_MAXITER = 1000;
 }


### PR DESCRIPTION
This PR removes a redundant definition of the frozen soils max iteration number `FROZEN_MAXITER` in `initialize_parameters.c`. (Previously `FROZEN_MAXITER` was defined twice in exactly the same way) 

- [ ] ~closes #xxx~
- [x] tests passed
- [ ] ~new tests added~
- [ ] ~science test figures~
- [X] ran uncrustify prior to final commit
- [ ] ~ReleaseNotes entry~
