### PR TITLE
print parameters struct after global param and options structs in ima…

### DIFF
--- a/vic/drivers/cesm/src/cesm_interface_c.c
+++ b/vic/drivers/cesm/src/cesm_interface_c.c
@@ -115,9 +115,10 @@ vic_cesm_init(vic_clock     *vclock,
 
     // initialization is complete, print settings
     log_info(
-        "Initialization is complete, print global param and options structures");
+        "Initialization is complete, print global param, parameters and options structures");
     print_global_param(&global_param);
     print_option(&options);
+    print_parameters(&param);
 
     // stop init timer
     timer_stop(&(global_timers[TIMER_VIC_INIT]));

--- a/vic/drivers/image/src/vic_image.c
+++ b/vic/drivers/image/src/vic_image.c
@@ -132,9 +132,10 @@ main(int    argc,
 
     // Initialization is complete, print settings
     log_info(
-        "Initialization is complete, print global param and options structures");
+        "Initialization is complete, print global param, parameters and options structures");
     print_global_param(&global_param);
     print_option(&options);
+    print_parameters(&param);
 
     // stop init timer
     timer_stop(&(global_timers[TIMER_VIC_INIT]));


### PR DESCRIPTION
…ge and cesm drivers

This quick PR adds printing the parameters struct after model initialization to the image and CESM drivers. This facilitates quick checking of parameter values in the log file. 

- [ ] closes #xxx
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [X] ran uncrustify prior to final commit
- [ ] ReleaseNotes entry
