### PR TITLE
Feature/check nveg

### DIFF
--- a/vic/drivers/shared_image/src/vic_init.c
+++ b/vic/drivers/shared_image/src/vic_init.c
@@ -1196,7 +1196,7 @@ vic_init(void)
                 if (sum <= 0) {
                     sprint_location(locstr, &(local_domain.locations[i]));
                     log_err("Root zone depths must sum to a value greater "
-                            "than 0 (sum = %.2f) - Type: %zd.\n%s", sum, j,
+                            "than 0 (sum = %.16f) - Type: %zd.\n%s", sum, j,
                             locstr);
                 }
                 sum = 0;
@@ -1205,10 +1205,10 @@ vic_init(void)
                 }
                 if (!assert_close_double(sum, 1.0, 0., AREA_SUM_ERROR_THRESH)) {
                     sprint_location(locstr, &(local_domain.locations[i]));
-                    log_warn("Root zone fractions sum to more than 1 (%f), "
-                             "normalizing fractions.  If the sum is large, "
-                             "check your vegetation parameter file.\n%s",
-                             sum, locstr);
+                    log_warn("Sum of root zone fractions !=  1.0 (%.16f) at "
+                             "grid cell %zd. Normalizing fractions. If the "
+                             "sum is large, check your vegetation parameter "
+                             "file.\n%s", sum, i, locstr);
                     for (k = 0; k < options.ROOT_ZONES; k++) {
                         veg_con[i][vidx].zone_fract[k] /= sum;
                     }
@@ -1245,8 +1245,9 @@ vic_init(void)
         // readjust Cvs to sum to 1.0
         if (!assert_close_double(Cv_sum[i], 1., 0., AREA_SUM_ERROR_THRESH)) {
             sprint_location(locstr, &(local_domain.locations[i]));
-            log_warn("Cv !=  1.0 (%f) at grid cell %zd. Adjusting fractions "
-                     "...\n%s", Cv_sum[i], i, locstr);
+            log_warn("Sum of veg tile area fractions !=  1.0 (%.16f) at grid "
+                     "cell %zd. Adjusting fractions ...\n%s", Cv_sum[i], i,
+                     locstr);
             for (j = 0; j < options.NVEGTYPES; j++) {
                 vidx = veg_con_map[i].vidx[j];
                 if (vidx != NODATA_VEG) {

--- a/vic/drivers/shared_image/src/vic_init.c
+++ b/vic/drivers/shared_image/src/vic_init.c
@@ -1136,6 +1136,13 @@ vic_init(void)
                 veg_con_map[i].vidx[j] = NODATA_VEG;
             }
         }
+        // check the number of nonzero veg tiles
+        if (k > local_domain.locations[i].nveg) {
+            sprint_location(locstr, &(local_domain.locations[i]));
+            log_err("Number of veg tiles with nonzero area (%zu) > nveg "
+                    "(%zu).\n%s", k, local_domain.locations[i].nveg,
+                    locstr);
+        }
     }
 
     // zone_depth: root zone depths
@@ -1242,7 +1249,9 @@ vic_init(void)
                      "...\n%s", Cv_sum[i], i, locstr);
             for (j = 0; j < options.NVEGTYPES; j++) {
                 vidx = veg_con_map[i].vidx[j];
-                veg_con[i][vidx].Cv /= Cv_sum[i];
+                if (vidx != NODATA_VEG) {
+                    veg_con[i][vidx].Cv /= Cv_sum[i];
+                }
             }
         }
     }

--- a/vic/drivers/shared_image/src/vic_init.c
+++ b/vic/drivers/shared_image/src/vic_init.c
@@ -1137,9 +1137,15 @@ vic_init(void)
             }
         }
         // check the number of nonzero veg tiles
-        if (k > local_domain.locations[i].nveg) {
+        if (k > local_domain.locations[i].nveg + 1) {
             sprint_location(locstr, &(local_domain.locations[i]));
-            log_err("Number of veg tiles with nonzero area (%zu) > nveg "
+            log_err("Number of veg tiles with nonzero area (%zu) > nveg + 1 "
+                    "(%zu).\n%s", k, local_domain.locations[i].nveg,
+                    locstr);
+        }
+        else if (k < local_domain.locations[i].nveg) {
+            sprint_location(locstr, &(local_domain.locations[i]));
+            log_err("Number of veg tiles with nonzero area (%zu) < nveg "
                     "(%zu).\n%s", k, local_domain.locations[i].nveg,
                     locstr);
         }


### PR DESCRIPTION
- [x] addresses #787 but doesn't close it
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] ran uncrustify prior to final commit
- [ ] ReleaseNotes entry

Just added a minor check to `vic_init()` that for each cell, `nNonzero <= nveg`, where `nNnonzero` is the number of veg tiles with `Cv > 0`.  `nveg` is allowed to be greater than this number due to potentially adding extra tiles for bare soil and above treeline vegetation.  But `nveg` from the parameter file should never be less than `nNonzero`.

Also modified warning messages for when either `Cv` or `root_frac` don't sum to what we want them to.  These messages now use format `.16f` to show the user more precisely what the sum comes to.

The motivation for this new check is that the logic for the mapping between `veg_con_map` and `veg_con` relies only on `Cv` to decide if a veg tile is valid.  Yet elsewhere in the code, `nveg` is used.  It's possible that these two quantities could get out of sync for a variety of reasons, which would result in assignment of unintended parameter values (from invalid tiles) to the `veg_con` structure.  This check avoids that and ensures internal consistency.