### PR TITLE
Fixed incorrect passing of lake_con structure to vic_run() and put_data().

### DIFF
--- a/vic/drivers/shared_image/src/vic_image_run.c
+++ b/vic/drivers/shared_image/src/vic_image_run.c
@@ -39,7 +39,7 @@ vic_image_run(dmy_struct *dmy_current)
     extern domain_struct       local_domain;
     extern option_struct       options;
     extern global_param_struct global_param;
-    extern lake_con_struct     lake_con;
+    extern lake_con_struct    *lake_con;
     extern double           ***out_data;
     extern stream_struct      *output_streams;
     extern save_data_struct   *save_data;
@@ -67,11 +67,11 @@ vic_image_run(dmy_struct *dmy_current)
 
         timer_start(&timer);
         vic_run(&(force[i]), &(all_vars[i]), dmy_current, &global_param,
-                &lake_con, &(soil_con[i]), veg_con[i], veg_lib[i]);
+                &(lake_con[i]), &(soil_con[i]), veg_con[i], veg_lib[i]);
         timer_stop(&timer);
 
         put_data(&(all_vars[i]), &(force[i]), &(soil_con[i]), veg_con[i],
-                 veg_lib[i], &lake_con, out_data[i], &(save_data[i]),
+                 veg_lib[i], &(lake_con[i]), out_data[i], &(save_data[i]),
                  &timer);
     }
 


### PR DESCRIPTION
- [x] closes #754 
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] ran uncrustify prior to final commit
- [ ] ReleaseNotes entry
