### PR TITLE
Fixed typo in vic_store.c that wrote wrong variable as lake soil T.

### DIFF
--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -966,7 +966,7 @@ vic_store(dmy_struct *dmy_state,
         for (j = 0; j < options.Nnode; j++) {
             d3start[0] = j;
             for (i = 0; i < local_domain.ncells_active; i++) {
-                dvar[i] = (double) all_vars[i].lake_var.soil.layer[j].moist;
+                dvar[i] = (double) all_vars[i].lake_var.energy.T[j];
             }
             gather_put_nc_field_double(nc_state_file.nc_id,
                                        nc_var->nc_varid,


### PR DESCRIPTION
- [x] closes #841 
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] ran uncrustify prior to final commit
- [ ] ReleaseNotes entry

Note: thanks to @itzetoile (Itzel Ruvalcaba) for catching this.