### PR TITLE
add support for 25km

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -125,7 +125,10 @@ This is a minor update from VIC 5.0.1. The VIC 5.1.0 includes new features, such
 
    1. [GH#866](https://github.com/UW-Hydro/VIC/pull/866) 
 
-    - Updates the default output variables for the CESM driver. Also updates the VIC5 parameter file location to be the RASM inputdata directory and updates the name of the VIC5 parameter file to the new VIC5 parameters. 
+    - Updates the default output variables for the CESM driver. Also updates the VIC5 parameter file location to be the RASM inputdata directory and updates the name of the VIC5 parameter file to the new VIC5 parameters.
+
+   1. [GH#869](https://github.com/UW-Hydro/VIC/pull/869)
+    - Adds support to the CESM driver for 25km resolution RASM runs. 
 
 3. Speed up NetCDF operations in the image/CESM drivers ([GH#684](https://github.com/UW-Hydro/VIC/pull/684))
 

--- a/vic/drivers/cesm/bld/vic.inputfiles.cfg
+++ b/vic/drivers/cesm/bld/vic.inputfiles.cfg
@@ -3,3 +3,9 @@ vic_domain = ${DIN_LOC_ROOT}/share/domains/domain.lnd.wr50a_ar9v4.100920.nc
 vic_params = ${DIN_LOC_ROOT}/lnd/vic/param/new_vic5_params_wr50a_ar9v4_all_options.nc
 vic_global_param = vic.globalconfig.txt
 vic_constants = vic.constants.txt
+
+[wr25b]
+vic_domain = ${DIN_LOC_ROOT}/share/domains/domain.lnd.wr25b_ar9v4.170413.nc
+vic_params = ${DIN_LOC_ROOT}/lnd/vic/param/new_vic5_params_wr25b_ar9v4_all_options.nc
+vic_global_param = vic.globalconfig.txt
+vic_constants = vic.constants.txt


### PR DESCRIPTION
- [X] closes #868 
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] ran uncrustify prior to final commit
- [X] ReleaseNotes entry

This PR adds support to the CESM driver for 25km RASM runs with a new set of high-resolution parameters. 
