### PR TITLE
Feature/update cesm driver statefile name

### DIFF
--- a/docs/Development/ReleaseNotes.md
+++ b/docs/Development/ReleaseNotes.md
@@ -133,6 +133,9 @@ This is a minor update from VIC 5.0.1. The VIC 5.1.0 includes new features, such
    1. [GH#871](https://github.com/UW-Hydro/VIC/pull/871) 
     - Adds initial state files to default 50km and 25km builds so that these are used by other groups running RASM rather than VIC5 starting up from a clean start. 
 
+   1. [GH#880](https://github.com/UW-Hydro/VIC/pull/880)
+    --Adds option STATENAME_CESM to the option_struct so that statefiles in the CESM driver can be in accordance with RASM naming conventions for model components. 
+
 3. Speed up NetCDF operations in the image/CESM drivers ([GH#684](https://github.com/UW-Hydro/VIC/pull/684))
 
     These changes speed up image driver initialization, forcing reads, and history writes by only opening and closing each input netCDF file once.

--- a/tests/unit/vic_run/test_modify_Ksat.py
+++ b/tests/unit/vic_run/test_modify_Ksat.py
@@ -1,6 +1,6 @@
 from vic import lib as vic_lib
 import numpy as np
-from scipy.interpolate.interpolate_wrapper import linear
+from scipy.interpolate import interp1d
 
 
 def test_linear_interp():
@@ -8,7 +8,8 @@ def test_linear_interp():
     x = np.arange(n, dtype=np.float)
     y = np.arange(n, dtype=np.float)
     new_x = np.arange(n, dtype=np.float) + 0.5
-    scipy_new_y = linear(x, y, new_x)
+    f = interp1d(x, y)
+    scipy_new_y = f(new_x)
     np.testing.assert_almost_equal(scipy_new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
     for i in range(n - 1):
         assert vic_lib.linear_interp(new_x[i], x[i], x[i + 1],

--- a/tests/unit/vic_run/test_modify_Ksat.py
+++ b/tests/unit/vic_run/test_modify_Ksat.py
@@ -8,7 +8,7 @@ def test_linear_interp():
     x = np.arange(n, dtype=np.float)
     y = np.arange(n, dtype=np.float)
     new_x = np.arange(n, dtype=np.float) + 0.5
-    f = interp1d(x, y)
+    f = interp1d(x, y, bounds_error=False, fill_value='extrapolate')
     scipy_new_y = f(new_x)
     np.testing.assert_almost_equal(scipy_new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
     for i in range(n - 1):

--- a/vic/drivers/cesm/bld/vic.globalconfig.txt
+++ b/vic/drivers/cesm/bld/vic.globalconfig.txt
@@ -40,6 +40,7 @@ RC_MODE              RC_JARVIS
 
 # Input Files and PATHS
 INIT_STATE       {vic_initstate}
+STATENAME_CESM   TRUE
 CONSTANTS        {vic_constants}
 LOG_DIR          {rundir}/
 PARAMETERS       {vic_params}

--- a/vic/drivers/cesm/src/display_current_settings.c
+++ b/vic/drivers/cesm/src/display_current_settings.c
@@ -416,6 +416,14 @@ display_current_settings(int mode)
         fprintf(LOG_DEST, "SAVE_STATE\t\tFALSE\n");
     }
 
+    if (options.STATENAME_CESM) {
+        fprintf(LOG_DEST, "STATENAME_CESM\t\tTRUE\n");
+    }
+    else {
+        fprintf(LOG_DEST, "STATENAME_CESM\t\tFALSE\n");
+    }
+
+
     fprintf(LOG_DEST, "\n");
     fprintf(LOG_DEST, "Output Data:\n");
     fprintf(LOG_DEST, "Result dir:\t\t%s\n", filenames.result_dir);

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -278,12 +278,11 @@ get_global_param(FILE *gp)
                             "NETCDF3_64BIT_OFFSET, NETCDF4_CLASSIC, or NETCDF4.");
                 }
             }
-	    // Define state file name format if using CESM conventions
-	    else if (strcasecmp("STATENAME_CESM", optstr) == 0) {
+            // Define state file name format if using CESM conventions
+            else if (strcasecmp("STATENAME_CESM", optstr) == 0) {
                 sscanf(cmdstr, "%*s %s", flgstr);
                 options.STATENAME_CESM = str_to_bool(flgstr);
             }
-
 
             /*************************************
                Define parameter files

--- a/vic/drivers/cesm/src/get_global_param.c
+++ b/vic/drivers/cesm/src/get_global_param.c
@@ -278,6 +278,12 @@ get_global_param(FILE *gp)
                             "NETCDF3_64BIT_OFFSET, NETCDF4_CLASSIC, or NETCDF4.");
                 }
             }
+	    // Define state file name format if using CESM conventions
+	    else if (strcasecmp("STATENAME_CESM", optstr) == 0) {
+                sscanf(cmdstr, "%*s %s", flgstr);
+                options.STATENAME_CESM = str_to_bool(flgstr);
+            }
+
 
             /*************************************
                Define parameter files

--- a/vic/drivers/shared_all/src/initialize_options.c
+++ b/vic/drivers/shared_all/src/initialize_options.c
@@ -95,6 +95,7 @@ initialize_options()
     options.VEGPARAM_LAI = false;
     // state options
     options.STATE_FORMAT = UNSET_FILE_FORMAT;
+    options.STATENAME_CESM = false;
     options.INIT_STATE = false;
     options.SAVE_STATE = false;
     // output options

--- a/vic/drivers/shared_all/src/print_library_shared.c
+++ b/vic/drivers/shared_all/src/print_library_shared.c
@@ -526,7 +526,7 @@ print_option(option_struct *option)
     fprintf(LOG_DEST, "\tSAVE_STATE           : %s\n",
             option->SAVE_STATE ? "true" : "false");
     fprintf(LOG_DEST, "\tSTATENAME_CESM       : %s\n",
-	    option->STATENAME_CESM ? "true" : "false");
+            option->STATENAME_CESM ? "true" : "false");
     fprintf(LOG_DEST, "\tNoutstreams          : %zu\n", option->Noutstreams);
 }
 

--- a/vic/drivers/shared_all/src/print_library_shared.c
+++ b/vic/drivers/shared_all/src/print_library_shared.c
@@ -525,6 +525,8 @@ print_option(option_struct *option)
             option->INIT_STATE ? "true" : "false");
     fprintf(LOG_DEST, "\tSAVE_STATE           : %s\n",
             option->SAVE_STATE ? "true" : "false");
+    fprintf(LOG_DEST, "\tSTATENAME_CESM       : %s\n",
+	    option->STATENAME_CESM ? "true" : "false");
     fprintf(LOG_DEST, "\tNoutstreams          : %zu\n", option->Noutstreams);
 }
 

--- a/vic/drivers/shared_image/src/vic_mpi_support.c
+++ b/vic/drivers/shared_image/src/vic_mpi_support.c
@@ -488,7 +488,7 @@ create_MPI_option_struct_type(MPI_Datatype *mpi_type)
     MPI_Datatype   *mpi_types;
 
     // nitems has to equal the number of elements in option_struct
-    nitems = 55;
+    nitems = 56;
     blocklengths = malloc(nitems * sizeof(*blocklengths));
     check_alloc_status(blocklengths, "Memory allocation error.");
 
@@ -724,6 +724,10 @@ create_MPI_option_struct_type(MPI_Datatype *mpi_type)
 
     // bool SAVE_STATE;
     offsets[i] = offsetof(option_struct, SAVE_STATE);
+    mpi_types[i++] = MPI_C_BOOL;
+
+    // bool STATENAME_CESM
+    offsets[i] = offsetof(option_struct, STATENAME_CESM);
     mpi_types[i++] = MPI_C_BOOL;
 
     // make sure that the we have the right number of elements

--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -62,10 +62,10 @@ vic_store(dmy_struct *dmy_state,
 
     // create netcdf file for storing model state
     if (options.STATENAME_CESM) {
-	sprintf(filename, "%s.vic.r.%04i-%02i-%02i-%05u.nc",
-	        filenames.statefile, dmy_state->year,
-		dmy_state->month, dmy_state->day,
-		dmy_state->dayseconds);
+        sprintf(filename, "%s.vic.r.%04i-%02i-%02i-%05u.nc",
+                filenames.statefile, dmy_state->year,
+                dmy_state->month, dmy_state->day,
+                dmy_state->dayseconds);
     }
     else {
         sprintf(filename, "%s.%04i%02i%02i_%05u.nc",

--- a/vic/drivers/shared_image/src/vic_store.c
+++ b/vic/drivers/shared_image/src/vic_store.c
@@ -61,10 +61,18 @@ vic_store(dmy_struct *dmy_state,
     set_nc_state_file_info(&nc_state_file);
 
     // create netcdf file for storing model state
-    sprintf(filename, "%s.%04i%02i%02i_%05u.nc",
-            filenames.statefile, dmy_state->year,
-            dmy_state->month, dmy_state->day,
-            dmy_state->dayseconds);
+    if (options.STATENAME_CESM) {
+	sprintf(filename, "%s.vic.r.%04i-%02i-%02i-%05u.nc",
+	        filenames.statefile, dmy_state->year,
+		dmy_state->month, dmy_state->day,
+		dmy_state->dayseconds);
+    }
+    else {
+        sprintf(filename, "%s.%04i%02i%02i_%05u.nc",
+                filenames.statefile, dmy_state->year,
+                dmy_state->month, dmy_state->day,
+                dmy_state->dayseconds);
+    }
 
     initialize_state_file(filename, &nc_state_file, dmy_state);
 

--- a/vic/vic_run/include/vic_def.h
+++ b/vic/vic_run/include/vic_def.h
@@ -287,6 +287,7 @@ typedef struct {
     unsigned short int STATE_FORMAT;  /**< TRUE = model state file is binary (default) */
     bool INIT_STATE;     /**< TRUE = initialize model state from file */
     bool SAVE_STATE;     /**< TRUE = save state file */
+    bool STATENAME_CESM; /**< TRUE = use CESM statefile naming conventions */
 
     // output options
     size_t Noutstreams;  /**< Number of output stream */


### PR DESCRIPTION
- [ ] closes #879 
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [X] ran uncrustify prior to final commit
- [x] ReleaseNotes entry

This PR adds an option called `STATENAME_CESM` to the CESM driver to enable naming a statefile in accordance with RASM conventions. It has not been implemented in the image, classic or python drivers since I don't foresee a usecase in which this would be necessary. But this can be updated if need be. 
