### PR TITLE
Unit conversion bug in Support/vic.4.2.glacier

### DIFF
--- a/src/glacier.c
+++ b/src/glacier.c
@@ -81,7 +81,7 @@ gl_volume_area(snow_data_struct **snow,
             if (ice_vol > 0.0) {
                 // ice_vol in km3 and ice_area in km2
                 ice_vol *= cell_area / MMPERMETER / METERS_PER_KM;
-                ice_area_old *= veg_con[iveg].Cv * cell_area;
+                ice_area_old *= cell_area;
 
                 // find new ice area
                 ice_area_temp = pow((ice_vol / BAHR_C), (1 / BAHR_LAMBDA));


### PR DESCRIPTION
Removed second multiplication by `veg_con[iveg].Cv` in glacier.c, line #84

This addresses issue #888 
