### PR TITLE
Support/vic.4.2.glacier

### DIFF
--- a/src/glacier.c
+++ b/src/glacier.c
@@ -90,6 +90,12 @@ gl_volume_area(snow_data_struct **snow,
                 ice_area_new = ice_area_old +
                                (ice_area_temp - ice_area_old) * exp(stepsize / BAHR_T);
 
+                // Check for negative new area after scaling due to ice volume loss
+                // Ignore scaling in this edge case
+                if (ice_area_new < 0.0) {
+                    ice_area_new = ice_area_old;
+                }
+
                 // Make sure the area isn't too big
                 overflow_vol = 0.;
                 if (ice_area_new > tile_area) {


### PR DESCRIPTION
This fixes issue #890.  The test case that was crashing on UW machine h2o, NCAR Cheyenne, and NCAR hydro-c1 now runs to completion on hydro-c1 with no negative `bot_band` values.

The fix simply ignores the time scaling when `ice_area_new` is negative and sets `ice_area_new = ice_area_old`.  Because this is within the positive `ice_vol` if statement (line 81), `ice_area_old is > 0` and the while statement on line 107 will be executed at least once moving `bot_band` to zero or larger.

This fix should probably still be tested on h2o and Cheyenne?  I can test on Cheyenne.