### PR TITLE
cffi headers: respect $CC if defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ matrix:
         - libnetcdf-dev
         - netcdf-bin
         - netcdf-doc
-        - gfortran
+        - gcc-4.8
+        - gfortran-4.8
         # open-mpi is built from source in cesm.travis
   # Classic Driver
   - compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
   # CESM Driver
   - compiler: gcc
     os: linux
-    env: TESTID='cesm'
+    env: TESTID='cesm' USE_CC=gcc-4.8
     addons:
       apt_packages:
         - libnetcdf-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,14 +33,13 @@ matrix:
   # CESM Driver
   - compiler: gcc
     os: linux
-    env: TESTID='cesm' USE_CC=gcc-4.8
+    env: TESTID='cesm'
     addons:
       apt_packages:
         - libnetcdf-dev
         - netcdf-bin
         - netcdf-doc
-        - gcc-4.8
-        - gfortran-4.8
+        - gfortran
         # open-mpi is built from source in cesm.travis
   # Classic Driver
   - compiler: clang
@@ -90,6 +89,16 @@ matrix:
   - compiler: gcc
     os: osx
     env: TESTID=classic BREW_INSTALLS=valgrind
+  # CESM Driver, started failing when travis upgraded to gcc5
+  - compiler: gcc
+    os: linux
+    env: TESTID='cesm'
+    addons:
+      apt_packages:
+        - libnetcdf-dev
+        - netcdf-bin
+        - netcdf-doc
+        - gfortran
 before_install:
   - source ci/vic_install_utils
   - source ci/${TESTID}.travis

--- a/vic/drivers/python/setup.py
+++ b/vic/drivers/python/setup.py
@@ -124,7 +124,7 @@ def make_cffi_headers():
                  'zwtvmoist_zwt',
                  'zwtvmoist_moist']
 
-    args = ['gcc', '-std=c99', '-E',
+    args = [os.environ.get('CC') or 'gcc', '-std=c99', '-E',
             '-P', os.path.join(vic_root_abs_path, 'vic', 'drivers',
                                'python', 'src', 'globals.c'),
             '-I%s' % os.path.join(vic_root_abs_path, 'vic', 'drivers',


### PR DESCRIPTION
default behavior is unchanged, but fixes builds on e.g. conda where compilers have funky names (https://github.com/conda-forge/vic-feedstock/pull/4) or `gcc` is not what should be used.

- [ ] closes #xxx
- [ ] tests passed
- [ ] new tests added
- [ ] science test figures
- [ ] ran uncrustify prior to final commit
- [ ] ReleaseNotes entry

I ran uncrustify but didn't commit the changes because it changed a bunch of C files that aren't related to this PR. There isn't a release notes section for the next unreleased version, so I didn't feel ready to start one with such a minor fix.